### PR TITLE
Tidy up samples.

### DIFF
--- a/Annotations/Annotations/Annotations.cs
+++ b/Annotations/Annotations/Annotations.cs
@@ -5,13 +5,7 @@ using Datalogics.PDFL;
  * 
  * This sample demonstrates how to find and describe annotations in an existing PDF document.
  * 
- * For more detail see the description of the Annotations sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/working-with-annotations#annotations
- *
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace Annotations

--- a/Annotations/InkAnnotations/InkAnnotations.cs
+++ b/Annotations/InkAnnotations/InkAnnotations.cs
@@ -8,13 +8,7 @@ using Datalogics.PDFL;
  * This sample creates and adds a new Ink annotation to a PDF document. An Ink annotation is a freeform line,
  * similar to what you would create with a pen, or with a stylus on a mobile device.
  *
- * For more detail see the description of the InkAnnotations sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/working-with-annotations#inkannotations
- *  
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Annotations/LinkAnnotation/LinkAnnotation.cs
+++ b/Annotations/LinkAnnotation/LinkAnnotation.cs
@@ -4,15 +4,8 @@ using Datalogics.PDFL;
 /*
  * 
  * This program creates a PDF file with an embedded hyperlink, which takes the reader to the second page of the document.
- * 
- * For more detail see the description of the LinkAnnotation sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/working-with-annotations#linkannotation
- * 
  *
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 // ReSharper disable once CheckNamespace

--- a/Annotations/PolyLineAnnotations/PolyLineAnnotations.cs
+++ b/Annotations/PolyLineAnnotations/PolyLineAnnotations.cs
@@ -8,10 +8,7 @@ using Datalogics.PDFL;
  * This program generates a PDF output file with a line shape (an angle) as an annotation to the file.
  * The program defines the vertices for the outlines of the annotation, and the line and fill colors.
  * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Annotations/PolygonAnnotations/PolygonAnnotations.cs
+++ b/Annotations/PolygonAnnotations/PolygonAnnotations.cs
@@ -8,10 +8,7 @@ using Datalogics.PDFL;
  * This program generates a PDF output file with a polygon shape (a triangle) as an annotation to the file.
  * The program defines the vertices for the outlines of the annotation, and the line and fill colors.
  *
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/AddElements/AddElements.cs
+++ b/ContentCreation/AddElements/AddElements.cs
@@ -9,10 +9,7 @@ using Datalogics.PDFL;
  * The third page features a rectangle and a curved design. Use this sample for ideas on how
  * to draw an image on a PDF page.
  * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/AddHeaderFooter/AddHeaderFooter.cs
+++ b/ContentCreation/AddHeaderFooter/AddHeaderFooter.cs
@@ -9,9 +9,6 @@ using Datalogics.PDFL;
  * 
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 namespace AddHeaderFooter

--- a/ContentCreation/Clips/Clips.cs
+++ b/ContentCreation/Clips/Clips.cs
@@ -6,13 +6,7 @@ using Datalogics.PDFL;
  * This sample demonstrates working with Clip objects. A clipping path is used to edit the borders of a graphics object.
  *
  * 
- * For more detail see the description of the Clips sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/manipulating-graphics-and-separating-colors-for-images
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/CreateBookmarks/CreateBookmarks.cs
+++ b/ContentCreation/CreateBookmarks/CreateBookmarks.cs
@@ -11,15 +11,12 @@ using Datalogics.PDFL;
  * For example, you could put bookmarks for each section heading, allowing a reader to
  * click on a hyperlink and move directly to that section from cross reference elsewhere in the document.
  * 
- * Open the Bookmark-out.PDF file in Acrobat and click the Bookmark icon to display the bookmarks that
+ * Open the Bookmark-out.PDF file in a PDF Viewer and click the Bookmark icon to display the bookmarks that
  * the CreateBookmarks program added to the output PDF document. Several of these bookmarks will zoom to
  * parts of the page. The last three, Child1, 2, and 3, are dummy bookmarks that do not respond when you
  * click on them.  They demonstrate how to rearrange existing bookmarks.
  * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/GradientShade/GradientShade.cs
+++ b/ContentCreation/GradientShade/GradientShade.cs
@@ -6,13 +6,7 @@ using Datalogics.PDFL;
  * This sample demonstrates changing the shading of an image on a PDF document page. The image gradually
  * changes from black on the left side of the image, to red on the right side.
  * 
- * For more detail see the description of the GradientShade sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/entering-or-generating-graphics-from-pdf-files
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace GradientShade

--- a/ContentCreation/MakeDocWithCalGrayColorSpace/MakeDocWithCalGrayColorSpace.cs
+++ b/ContentCreation/MakeDocWithCalGrayColorSpace/MakeDocWithCalGrayColorSpace.cs
@@ -4,13 +4,7 @@ using Datalogics.PDFL;
 /*
  * Demonstrates working with the Calibrated Gray Space (CaLGray), based on the CIE color space.
  *
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- * 
- * For more detail see the description of the ColorSpace sample programs on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/getting-pdf-documents-using-color-spaces
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/MakeDocWithCalRGBColorSpace/MakeDocWithCalRGBColorSpace.cs
+++ b/ContentCreation/MakeDocWithCalRGBColorSpace/MakeDocWithCalRGBColorSpace.cs
@@ -5,13 +5,7 @@ using Datalogics.PDFL;
  * Demonstrates working with the Calibrated RGB Color Space, based on the CIE color space.
  * A, B, and C represent red, blue, and green color values.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/getting-pdf-documents-using-color-spaces
- *
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/MakeDocWithDeviceNColorSpace/MakeDocWithDeviceNColorSpace.cs
+++ b/ContentCreation/MakeDocWithDeviceNColorSpace/MakeDocWithDeviceNColorSpace.cs
@@ -4,14 +4,8 @@ using Datalogics.PDFL;
 /*
  * This sample demonstrates creating a file containing a DeviceN color space.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/getting-pdf-documents-using-color-spaces
- *
  * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace MakeDocWithDeviceNColorSpace

--- a/ContentCreation/MakeDocWithICCBasedColorSpace/MakeDocWithICCBasedColorSpace.cs
+++ b/ContentCreation/MakeDocWithICCBasedColorSpace/MakeDocWithICCBasedColorSpace.cs
@@ -5,13 +5,7 @@ using Datalogics.PDFL;
 /*
  * This sample demonstrates creating a file containing an ICC-based color space.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/getting-pdf-documents-using-color-spaces
- *
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace MakeDocWithICCBasedColorSpace

--- a/ContentCreation/MakeDocWithIndexedColorSpace/MakeDocWithIndexedColorSpace.cs
+++ b/ContentCreation/MakeDocWithIndexedColorSpace/MakeDocWithIndexedColorSpace.cs
@@ -6,15 +6,8 @@ using Datalogics.PDFL;
  * Demonstrates working with the Indexed Color Space. Indexed Color Spaces are used
  * to reduce the amount of system memory used for processing images when a limited
  * number of colors are needed.
- *
- * For more detail see the description of the ColorSpace sample programs on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/getting-pdf-documents-using-color-spaces
- *
  * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/MakeDocWithLabColorSpace/MakeDocWithLabColorSpace.cs
+++ b/ContentCreation/MakeDocWithLabColorSpace/MakeDocWithLabColorSpace.cs
@@ -6,14 +6,8 @@ using Datalogics.PDFL;
  * CIE XYZ color space, but it includes a dimension L, for lightness,
  * along with a and b coordinates, to define the color.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/getting-pdf-documents-using-color-spaces
- *
  * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/MakeDocWithSeparationColorSpace/MakeDocWithSeparationColorSpace.cs
+++ b/ContentCreation/MakeDocWithSeparationColorSpace/MakeDocWithSeparationColorSpace.cs
@@ -4,14 +4,8 @@ using Datalogics.PDFL;
 /*
  * This sample demonstrates creating a PDF document that uses a Separation color space.
  *
- * For more detail see the description of the ColorSpace sample programs on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/getting-pdf-documents-using-color-spaces
- *
  * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace MakeDocWithSeparationColorSpace

--- a/ContentCreation/NameTrees/NameTrees.cs
+++ b/ContentCreation/NameTrees/NameTrees.cs
@@ -9,13 +9,7 @@ using Datalogics.PDFL;
  * dictionary, instead of using a code value as a key to identify an object, a name tree
  * uses names as keys to map to data objects. 
  *
- * For more detail see the description of the NameTrees sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/working-with-large-amounts-of-data-in-a-pdf
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/NumberTrees/NumberTrees.cs
+++ b/ContentCreation/NumberTrees/NumberTrees.cs
@@ -9,13 +9,7 @@ using Datalogics.PDFL;
  * keys used in a number tree are integers, rather than character strings, and these keys are sorted
  * in ascending numerical order. 
  *
- * For more detail see the description of the NumberTrees sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/working-with-large-amounts-of-data-in-a-pdf
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/RemoteGoToActions/RemoteGoToActions.cs
+++ b/ContentCreation/RemoteGoToActions/RemoteGoToActions.cs
@@ -9,13 +9,7 @@ using Datalogics.PDFL;
  * RemoteGoToActions differs from LaunchActions in that it includes a RemoteDestination object.
  * This object describes the rectangle used in the PDF file in a series of statements at the command prompt. 
  *
- * For more detail see the description of the AnnotationCopyPaste sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/working-with-actions-in-pdf-files#remotegotoactions
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentCreation/WriteNChannelTiff/WriteNChannelTiff.cs
+++ b/ContentCreation/WriteNChannelTiff/WriteNChannelTiff.cs
@@ -6,13 +6,7 @@ using Datalogics.PDFL;
  * This sample generates a multi-page TIFF file, selecting graphics drawn from
  * the first page of the PDF document provided.
  * 
- * For more detail see the description of the WriteNChannelTiff sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/manipulating-graphics-and-separating-colors-for-images#writenchanneltiff
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/Action/Action.cs
+++ b/ContentModification/Action/Action.cs
@@ -6,10 +6,7 @@ using Datalogics.PDFL;
  * An action is added to the rectangle in the form of a hyperlink; if the reader
  * clicks on the rectangle, the system opens a Datalogics web page.
  *
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace Action

--- a/ContentModification/AddCollection/AddCollection.cs
+++ b/ContentModification/AddCollection/AddCollection.cs
@@ -7,14 +7,8 @@ using Datalogics.PDFL;
  * 
  * A PDF Portfolio can hold and display multiple additional files as attachments.
  * 
- * For more detail see the description of the AddCollection sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/working-with-a-pdf-collection-or-portfolio
- * 
  *
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace AddCollection

--- a/ContentModification/ChangeLayerConfiguration/ChangeLayerConfiguration.cs
+++ b/ContentModification/ChangeLayerConfiguration/ChangeLayerConfiguration.cs
@@ -6,19 +6,13 @@ using Datalogics.PDFL;
  * This sample changes the On/Off configuration for a set of Optional Content Groups,
  * or layers, within a PDF document. By changing the On or Off state in the default
  * configuration, the sample makes the layers visible or invisible when opened in a 
- * viewer like Adobe Acrobat.
+ * PDF viewer.
  * 
  * The sample changes the states of the layers in the document called Layers.pdf and
  * saves the result to a new PDF document.
  * 
- * For more detail see the description of the ChangeLayerConfiguration sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/layers-and-transparencies/ 
  * 
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace ChangeLayerConfiguration

--- a/ContentModification/ChangeLinkColors/ChangeLinkColors.cs
+++ b/ContentModification/ChangeLinkColors/ChangeLinkColors.cs
@@ -8,15 +8,9 @@ using Datalogics.PDFL;
  * The program works by identifying text in a PDF file that is associated with hyperlinks.
  * Each link appears as a rectangle layer in the PDF file; ChangeLinkColors identifies these
  * rectangles, and then finds the text that lines up within these rectangles and changes the
- * color of each character that is a part of the hyperlink.  
+ * color of each character that is a part of the hyperlink.
  * 
- * For more detail see the description of the ChangeLinkColors sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/working-with-annotations#changelinkcolors
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace ChangeLinkColors

--- a/ContentModification/CreateLayer/CreateLayer.cs
+++ b/ContentModification/CreateLayer/CreateLayer.cs
@@ -8,14 +8,9 @@ using Datalogics.PDFL;
  * The related ChangeLayerConfiguration program makes layers visible or invisible.
  * 
  * You can toggle back and forth to make the layer (the duck image) visible or invisible
- * in the PDF file. Open the output PDF document in Adobe Acrobat, click View and select
- * Show/Hide. Select Navigation Panes and Layers to display the layers in the PDF file. 
- * Click on the box next to the name of the layer.
+ * in the PDF file.
  *
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace CreateLayer

--- a/ContentModification/ExtendedGraphicStates/ExtendedGraphicStates.cs
+++ b/ContentModification/ExtendedGraphicStates/ExtendedGraphicStates.cs
@@ -10,13 +10,7 @@ using Datalogics.PDFL;
  * 
  * This sample program shows how to use the Extended Graphic State object to add graphics parameters to an image.
  * 
- * For more detail see the description of the ExtendedGraphicState sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/adding-text-and-graphic-elements#extendedgraphicstates
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/FlattenTransparency/FlattenTransparency.cs
+++ b/ContentModification/FlattenTransparency/FlattenTransparency.cs
@@ -11,14 +11,8 @@ using Datalogics.PDFL;
  * appears on the page. The process to flatten a set of transparencies merges them
  * into a single image on the page.
  *
- * For more detail see the description of the FlattenTransparency sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/layers_and_transparencies#flattentransparency
  * 
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/LaunchActions/LaunchActions.cs
+++ b/ContentModification/LaunchActions/LaunchActions.cs
@@ -6,10 +6,7 @@ using Datalogics.PDFL;
  * An action is added to the rectangle in the form of a hyperlink; if the reader clicks
  * on the rectangle, a different PDF file opens, showing an image.
  * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/MergePDF/MergePDF.cs
+++ b/ContentModification/MergePDF/MergePDF.cs
@@ -7,10 +7,7 @@ using Datalogics.PDFL;
  * prompts the user to enter the names of two PDF files, and then inserts the content 
  * of the second PDF file into the first PDF file and saves the result in a third PDF file.
  *
- * Copyright (c) 2007-2021, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/PDFObject/PDFObject.cs
+++ b/ContentModification/PDFObject/PDFObject.cs
@@ -6,14 +6,8 @@ using Datalogics.PDFL;
  * This sample demonstrates working with data objects in a PDF document. It examines the Objects and displays
  * information about them.  The sample extracts the dictionary for an object called URIAction and updates it using PDFObjects.
  * 
- * For more detail see the description of the PDFObject sample on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/listing-information-about-values-and-objects-in-pdf-files#pdfobject
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- * 
  * Suggested input file: Library.ResourceDirectory + "Sample_Input/sample_links.pdf"
  * Input file properties: First page must have an annotation with a URI link
  */

--- a/ContentModification/PageLabels/PageLabels.cs
+++ b/ContentModification/PageLabels/PageLabels.cs
@@ -11,10 +11,7 @@ using Datalogics.PDFL;
  * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/listing-information-about-values-and-objects-in-pdf-files#pagelabels
  * 
  * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/ContentModification/UnderlinesAndHighlights/UnderlinesAndHighlights.cs
+++ b/ContentModification/UnderlinesAndHighlights/UnderlinesAndHighlights.cs
@@ -9,10 +9,7 @@ using Datalogics.PDFL;
  * a National Weather Service web page, highlighting the word “Cloudy” wherever it appears and underlining
  * the word “Rain.”
  * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace UnderlinesAndHighlights

--- a/ContentModification/Watermark/Watermark.cs
+++ b/ContentModification/Watermark/Watermark.cs
@@ -10,13 +10,7 @@ using Datalogics.PDFL;
  * a set of photographs shown in a PDF file so that they cannot be easily duplicated without
  * the permission of the owner.
  * 
- * For more detail see the description of the Watermark sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/adding-text-and-graphic-elements#watermark
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/DisplayPDF/DisplayPDF.cs
+++ b/Display/DisplayPDF/DisplayPDF.cs
@@ -7,10 +7,7 @@ using Datalogics.PDFL;
  * This sample shows how to open a PDF document, search for text in the pages and highlight
  * the text.
  * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/DisplayPDF/DisplayPDFForm.Designer.cs
+++ b/Display/DisplayPDF/DisplayPDFForm.Designer.cs
@@ -1,10 +1,6 @@
 /*
-Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved. 
+Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved. 
 
-The information and code in this sample is for the exclusive use of Datalogics
-customers and evaluation users only.  Datalogics permits you to use, modify and
-distribute this file in accordance with the terms of your license agreement.
-Sample code is for demonstrative purposes only and is not intended for production use.
  */
 
 namespace DisplayPDF

--- a/Display/DisplayPDF/DisplayPDFForm.cs
+++ b/Display/DisplayPDF/DisplayPDFForm.cs
@@ -12,12 +12,7 @@ using Datalogics.PDFL;
  * Sample to demonstrate how to open a PDF document, search for text in
  * the pages and highlight the text using the C# drawing library.
  * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * The information and code in this sample is for the exclusive use of Datalogics
- * customers and evaluation users only.  Datalogics permits you to use, modify and
- * distribute this file in accordance with the terms of your license agreement.
- * Sample code is for demonstrative purposes only and is not intended for production use.
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Display/DisplayPDF/MyPictureBox.cs
+++ b/Display/DisplayPDF/MyPictureBox.cs
@@ -9,12 +9,8 @@ using System.Drawing.Drawing2D;
 using Datalogics.PDFL;
 
 /*
-Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved. 
-
-The information and code in this sample is for the exclusive use of Datalogics
-customers and evaluation users only.  Datalogics permits you to use, modify and
-distribute this file in accordance with the terms of your license agreement.
-Sample code is for demonstrative purposes only and is not intended for production use.
+Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved. 
+*
  */
 
 namespace DisplayPDF

--- a/DocumentConversion/ColorConvertDocument/ColorConvertDocument.cs
+++ b/DocumentConversion/ColorConvertDocument/ColorConvertDocument.cs
@@ -13,13 +13,7 @@ using Datalogics.PDFL;
  * Note that the color profile is not embedded by default; rather, the default is not to embed the color profile.
  * The user must set the option to embed to True.
  * 
- * For more detail see the description of the ColorConvertDocument sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/color-conversion
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace ColorConvertDocument

--- a/DocumentConversion/ConvertToOffice/ConvertToOffice.cs
+++ b/DocumentConversion/ConvertToOffice/ConvertToOffice.cs
@@ -5,13 +5,7 @@ using Datalogics.PDFL;
  * 
  * ConvertToOffice converts sample PDF documents to Office Documents.
  *
- * For more detail see the description of the ConvertToOffice sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/converting-and-merging-pdf-content
- * 
  * Copyright (c) 2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 namespace ConvertToOffice

--- a/DocumentConversion/CreateDocFromXPS/CreateDocFromXPS.cs
+++ b/DocumentConversion/CreateDocFromXPS/CreateDocFromXPS.cs
@@ -9,10 +9,7 @@ using Datalogics.PDFL;
  * XML Paper Specification (XPS) is a standard document format that Microsoft created in 2006
  * as an alternative to the PDF format.  
  *
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/DocumentConversion/Factur-XConverter/Factur-XConverter.cs
+++ b/DocumentConversion/Factur-XConverter/Factur-XConverter.cs
@@ -10,9 +10,6 @@ using Datalogics.PDFL;
  * 
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 namespace FacturXConverter
 {

--- a/DocumentConversion/PDFAConverter/PDFAConverter.cs
+++ b/DocumentConversion/PDFAConverter/PDFAConverter.cs
@@ -6,13 +6,7 @@ using Datalogics.PDFL;
  * This sample demonstrates converting a standard PDF document into a
  * PDF Archive, or PDF/A, compliant version of a PDF file.
  *
- * For more detail see the description of the PDFAConverter sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/converting-and-merging-pdf-content
- * 
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 namespace PDFAConverter

--- a/DocumentConversion/PDFXConverter/PDFXConverter.cs
+++ b/DocumentConversion/PDFXConverter/PDFXConverter.cs
@@ -9,13 +9,7 @@ using Datalogics.PDFL;
  * 
  * The sample takes a default input and output a document (both optional). 
  * 
- * For more detail see the description of the PDFXConverter sample program on our Developer’s site,
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/converting-and-merging-pdf-content#pdfxconverter
- *
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 namespace PDFXConverter

--- a/DocumentConversion/ZUGFeRDConverter/ZUGFeRDConverter.cs
+++ b/DocumentConversion/ZUGFeRDConverter/ZUGFeRDConverter.cs
@@ -5,13 +5,7 @@ using Datalogics.PDFL;
  * 
  * This sample demonstrates converting the input PDF with the input Invoice ZUGFeRD XML to a ZUGFeRD compliant PDF.
  *
- * For more detail see the description of the ZUGFeRDConverter sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/converting-and-merging-pdf-content/#zugferdconverter
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace ZUGFeRDConverter

--- a/DocumentOptimization/PDFOptimize/PDFOptimize.cs
+++ b/DocumentOptimization/PDFOptimize/PDFOptimize.cs
@@ -11,14 +11,8 @@ using System;
  * to suit your applications needs and drop such content to achieve better compression if you already
  * know it's unnecessary.
  * 
- * For more detail see the description of the PDFOptimizer sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-sample-programs/using-the-pdf-optimizer-to-manage-the-size-of-pdf-documents
- * 
  * 
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 namespace PDFOptimize

--- a/Images/DocToImages/DocToImages.cs
+++ b/Images/DocToImages/DocToImages.cs
@@ -8,14 +8,7 @@ using Datalogics.PDFL;
  * one per page. You can also create a mult-page TIFF file. This program requires that you enter 
  * formatting values manually at the command line. 
  *
- * For more detail, and information about the command line parameters, see the description of the DocToImages
- * sample program on our Developer's site,
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/converting-pdf-pages-to-images/#doctoimages
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/DrawSeparations/DrawSeparations.cs
+++ b/Images/DrawSeparations/DrawSeparations.cs
@@ -12,9 +12,6 @@ using System.IO;
  * 
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 namespace DrawSeparations

--- a/Images/DrawToBitmap/DrawToBitmap.cs
+++ b/Images/DrawToBitmap/DrawToBitmap.cs
@@ -13,10 +13,6 @@ using System.IO;
  * 
  * 
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 namespace DrawToBitmap

--- a/Images/EPSSeparations/EPSSeparations.cs
+++ b/Images/EPSSeparations/EPSSeparations.cs
@@ -7,14 +7,8 @@ using Datalogics.PDFL;
  * This sample demonstrates working with color separations with Encapsulated PostScript (EPS) graphics
  * from a PDF file.
  *
- * For more detail see the description of the EPSSeparations sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/manipulating-graphics-and-separating-colors-for-images#epsseparations
  * 
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace EPSSeparations

--- a/Images/GetSeparatedImages/GetSeparatedImages.cs
+++ b/Images/GetSeparatedImages/GetSeparatedImages.cs
@@ -5,14 +5,8 @@ using Datalogics.PDFL;
 /*
  * This sample demonstrates drawing a list of grayscale separations from a PDF file to multi-paged TIFF file.
  *
- * For more detail see the description of the GetSeparatedImages sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/manipulating-graphics-and-separating-colors-for-images#getseparatedimages
- * 
  * 
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 

--- a/Images/ImageEmbedICCProfile/ImageEmbedICCProfile.cs
+++ b/Images/ImageEmbedICCProfile/ImageEmbedICCProfile.cs
@@ -8,14 +8,7 @@ using Datalogics.PDFL;
  * The program sets up how the output will be rendered and generates a TIF image file or
  * series of TIF files as output.
  * 
- * For more detail see the description of the ImageEmbedICCProfile sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/exporting-images-from-pdf-files/#imageembediccprofile
- * 
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 namespace ImageEmbedICCProfile
 {

--- a/Images/ImageExport/ImageExport.cs
+++ b/Images/ImageExport/ImageExport.cs
@@ -12,13 +12,7 @@ using Datalogics.PDFL;
  * sets of graphics files for those three images. The sample program ignores text, parsing the
  * PDF syntax to identify any raster or vector images found on every page.
  *
- * For more detail see the description of the ImageExport sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/exporting-images-from-pdf-files
- * 
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 

--- a/Images/ImageExtraction/ImageExtraction.cs
+++ b/Images/ImageExtraction/ImageExtraction.cs
@@ -10,14 +10,8 @@ using SkiaSharp;
  * images from the PDF file and copies them to a separate set of graphics files in the
  * same directory. Vector images, such as clip art, will not be exported.
  * 
- * For more detail see the description of the ImageExtraction sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/exporting-images-from-pdf-files/#imageextraction
- * 
  * 
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 

--- a/Images/ImageFromStream/ImageFromStream.cs
+++ b/Images/ImageFromStream/ImageFromStream.cs
@@ -11,15 +11,8 @@ using SkiaSharp;
  * that is used to interpret the values in the stream.
  * 
  * This program is similar to StreamIO.
- *
- * For more detail see the description of the ImagefromStream sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/exporting-images-from-pdf-files/#imagefromstream
- * 
  * 
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
  *
  */
 namespace ImageFromStream

--- a/Images/ImageImport/ImageImport.cs
+++ b/Images/ImageImport/ImageImport.cs
@@ -7,10 +7,7 @@ using Datalogics.PDFL;
  * prompting you, and creates two PDF files, demonstrating how to import graphics from image files
  * into a PDF file. One of the PDF output files is the result of graphics imported from a multi-page TIF file.
  * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageResampling/ImageResampling.cs
+++ b/Images/ImageResampling/ImageResampling.cs
@@ -10,13 +10,7 @@ using Datalogics.PDFL;
  * used to reduce the resolution of an image or series of images, to make them smaller. As a result
  * the process makes the PDF document smaller.
  *
- * For more detail see the description of the ImageResampling sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/entering-or-generating-graphics-from-pdf-files
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/ImageSoftMask/ImageSoftMask.cs
+++ b/Images/ImageSoftMask/ImageSoftMask.cs
@@ -7,13 +7,7 @@ using Datalogics.PDFL;
  * change a feature, while a soft mask allows you to place an image on a page and define the level of 
  * transparency for that image.
  *
- * For more detail see the description of the ImageSoftMask sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/entering-or-generating-graphics-from-pdf-files
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Images/RasterizePage/RasterizePage.cs
+++ b/Images/RasterizePage/RasterizePage.cs
@@ -26,9 +26,6 @@ using SkiaSharp;
  *
  * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 namespace RasterizePage
 {

--- a/InformationExtraction/ListBookmarks/ListBookmarks.cs
+++ b/InformationExtraction/ListBookmarks/ListBookmarks.cs
@@ -5,14 +5,8 @@ using Datalogics.PDFL;
  * 
  * This sample finds and describes the bookmarks included in a PDF document.
  * 
- * For more detail see the description of the List sample programs, and ListBookmarks, on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/listing-information-about-values-and-objects-in-pdf-files
  * 
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/InformationExtraction/ListInfo/ListInfo.cs
+++ b/InformationExtraction/ListInfo/ListInfo.cs
@@ -7,13 +7,7 @@ using Datalogics.PDFL;
  * if you want to change these values, such as the title or author. The results are exported
  * to a PDF output document.
  * 
- * For more detail see the description of the List sample programs, and ListInfo, on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/listing-information-about-values-and-objects-in-pdf-files
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/InformationExtraction/ListLayers/ListLayers.cs
+++ b/InformationExtraction/ListLayers/ListLayers.cs
@@ -3,15 +3,9 @@ using System.Collections.Generic;
 using Datalogics.PDFL;
 
 /*
- * This sample searches for and lists the names of the color layers found in a PDF document. 
+ * This sample searches for and lists the names of the color layers found in a PDF document.
  *  
- * For more detail see the description of the List sample programs, and ListLayers, on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/listing-information-about-values-and-objects-in-pdf-files
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/InformationExtraction/ListPaths/ListPaths.cs
+++ b/InformationExtraction/ListPaths/ListPaths.cs
@@ -6,13 +6,7 @@ using Datalogics.PDFL;
  * This sample searches for and lists the contents of paths found in an existing PDF document.
  * Paths in PDF documents, or clipping paths, define the boundaries for art or graphics.
  * 
- * For more detail see the description of the List sample programs, and ListPaths, on our Developer's site,
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/listing-information-about-values-and-objects-in-pdf-files
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/InformationExtraction/Metadata/Metadata.cs
+++ b/InformationExtraction/Metadata/Metadata.cs
@@ -8,13 +8,7 @@ using System.Xml;
  * This sample shows how to view and edit metadata for a PDF document. The metadata values appear on the Properties
  * window in Adobe Reader and Adobe Acrobat. Click File/Properties, and then click Additional Metadata.
  *
- * For more detail see the description of the Metadata sample on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/listing-information-about-values-and-objects-in-pdf-files#metadata
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/OpticalCharacterRecognition/AddTextToDocument/AddTextToDocument.cs
+++ b/OpticalCharacterRecognition/AddTextToDocument/AddTextToDocument.cs
@@ -6,13 +6,7 @@ using Datalogics.PDFL;
  * Process a document using the optical recognition engine.
  * Then place the image and the processed text in an output pdf
  * 
- * For more detail see the description of AddTextToDocument on our Developers site, 
- * https://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/optical-character-recognition/
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/OpticalCharacterRecognition/AddTextToImage/AddTextToImage.cs
+++ b/OpticalCharacterRecognition/AddTextToImage/AddTextToImage.cs
@@ -6,13 +6,7 @@ using Datalogics.PDFL;
  * The sample uses an image as input which will be processed by the optical recognition engine.
  * We will then place the image and the processed text in an output pdf
  * 
- * For more detail see the description of AddTextToImage, on our Developers site, 
- * https://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/optical-character-recognition/
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Other/MemoryFileSystem/MemoryFileSystem.cs
+++ b/Other/MemoryFileSystem/MemoryFileSystem.cs
@@ -10,10 +10,7 @@ using Datalogics.PDFL;
  * TempStoreType.Memory. The program can also set a maximum amount of RAM to use by
  * applying a value to the DefaultTempStoreMemLimit property.
  *
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace MemoryFileSystem

--- a/Other/StreamIO/StreamIO.cs
+++ b/Other/StreamIO/StreamIO.cs
@@ -13,13 +13,7 @@ using Datalogics.PDFL;
  * 
  * This program is similar to ImagefromStream, but in this example the PDF file streams hold text.
  *
- * For more detail see the description of the StreamIO sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/exporting-images-from-pdf-files/#streamio
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace StreamIO

--- a/Printing/PrintPDF/PrintPDF.cs
+++ b/Printing/PrintPDF/PrintPDF.cs
@@ -13,10 +13,7 @@ using Datalogics.PDFL;
  * runs and automatically generates a PDF output file from the PS file.  This file will match the PDF
  * file you entered to print.
  * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Printing/PrintPDFGUI/PrintPDFForm.Designer.cs
+++ b/Printing/PrintPDFGUI/PrintPDFForm.Designer.cs
@@ -3,12 +3,8 @@ using System.Collections.Generic;
 using System.Windows.Forms;
 
 /*
-Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved. 
+Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved. 
 
-The information and code in this sample is for the exclusive use of Datalogics
-customers and evaluation users only.  Datalogics permits you to use, modify and
-distribute this file in accordance with the terms of your license agreement.
-Sample code is for demonstrative purposes only and is not intended for production use.
  */
 
 namespace PrintPDFGUI

--- a/Printing/PrintPDFGUI/PrintPDFForm.cs
+++ b/Printing/PrintPDFGUI/PrintPDFForm.cs
@@ -5,14 +5,8 @@ using Datalogics.PDFL;
 /*
  * This sample printing a PDF file. It is similar to PrintPDF, but this
  * program provides a user interface.
- *
- * For more detail see the description of the PrintPDFGUI sample program on our Developer’s site,
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/printing-pdf-files-and-generating-postscript-ps-files-from-pdf
- *
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+*
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Printing/PrintPDFGUI/PrintPDFGUI.cs
+++ b/Printing/PrintPDFGUI/PrintPDFGUI.cs
@@ -7,13 +7,7 @@ using Datalogics.PDFL;
  * This sample printing a PDF file. It is similar to PrintPDF, but this
  * program provides a user interface.
  * 
- * For more detail see the description of the PrintPDFGUI sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/printing-pdf-files-and-generating-postscript-ps-files-from-pdf
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 [![Download a Free Trial on NuGet](https://img.shields.io/nuget/dt/Adobe.PDF.Library.LM.NET?color=blue&label=APDFL%20.NET%20Free%20Trial&logo=NuGet&style=plastic)](https://www.nuget.org/packages/Adobe.PDF.Library.LM.NET)
 
 # .NET Samples
-## ***Introduction***
+## Introduction
 Built upon Adobe source code used for Acrobat, Datalogics Adobe PDF Library SDK provides stable, reliable code and the flexibility to develop with C# or VB (VB.NET) (interfaces are also available for C++ and Java). APDFL is the most complete SDK for PDF creation, manipulation and management. Best for enterprise/larger organizations of developers and independent software vendors (ISVs) who need to incorporate Adobe's PDF functionality into their own internal or external applications.
 
-## ***Preliminaries***
+## Preliminaries
 Most of the code samples in APDFL are designed to demonstrate how an API works by completing a simple programming task.
 
 We assume a basic level of technical understanding of the PDF file format, invidual sample category directory markdown files go into more details.
@@ -17,7 +17,7 @@ Many of these sample programs automatically generate an output file or set of fi
 
 *(Note: that the Forms Extension product and samples are available by talking to Datalogics Sales.)*
 
-## ***Building and Running Samples***
+## Building and Running Samples
 *Samples can be built and run easily in an IDE such as Visual Studio 2022, Visual Studio 2022 for Mac, or VS Code.*
 
 **Otherwise**, here are instructions for using **dotnet** instead:

--- a/Security/AddRegexRedaction/AddRegexRedaction.cs
+++ b/Security/AddRegexRedaction/AddRegexRedaction.cs
@@ -7,10 +7,7 @@ using Datalogics.PDFL;
  * document that matches a user-supplied regular expression. When the sample finds the text it
  * will redact the phrase from the output document.
  * 
- * Copyright (c) 2007-2021, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace AddRegexRedaction

--- a/Security/Redactions/Redactions.cs
+++ b/Security/Redactions/Redactions.cs
@@ -7,13 +7,7 @@ using Datalogics.PDFL;
  * This sample shows how to redact a PDF document. The program opens an input PDF, searches for
  * specific words using the Adobe PDF Library WordFinder, and then removes these words from the text.
  * 
- * For more detail see the description of the Redactions sample program on our Developer's site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/redacting-text-from-a-pdf-document
- *
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace Redactions

--- a/Text/AddGlyphs/AddGlyphs.cs
+++ b/Text/AddGlyphs/AddGlyphs.cs
@@ -7,13 +7,7 @@ using Datalogics.PDFL;
  * Use this program to create a new PDF file and add glyphs to the page,
  * managing them by individual Glyph ID codes.
  * 
- * For more detail see the description of the AddGlyphs sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/adding-text-and-graphic-elements#addglyphs
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace AddGlyphs

--- a/Text/AddUnicodeText/AddUnicodeText.cs
+++ b/Text/AddUnicodeText/AddUnicodeText.cs
@@ -6,14 +6,8 @@ using Datalogics.PDFL;
  * 
  * This sample program adds six lines of Unicode text to a PDF file, in six different languages.
  *
- * For more detail see the description of the AddUnicodeText sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/adding-text-and-graphic-elements#addunicodetext
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- * 
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
+*
  */
 
 namespace AddUnicodeText

--- a/Text/AddVerticalText/AddVerticalText.cs
+++ b/Text/AddVerticalText/AddVerticalText.cs
@@ -10,10 +10,7 @@ using Datalogics.PDFL;
  * The sample offers several rows of Unicode characters. The sample PDF file thus presents multiple columns
  * of vertical text.  The characters appear in English as well as Mandarin, Japanese, and Korean.
  * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Text/ExtractAcroFormFieldData/ExtractAcroFormFieldData.cs
+++ b/Text/ExtractAcroFormFieldData/ExtractAcroFormFieldData.cs
@@ -9,9 +9,6 @@ using ExtractTextNameSpace;
  *
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 namespace ExtractAcroFormFieldData

--- a/Text/ExtractCJKTextByPatternMatch/ExtractCJKTextByPatternMatch.cs
+++ b/Text/ExtractCJKTextByPatternMatch/ExtractCJKTextByPatternMatch.cs
@@ -8,9 +8,6 @@ using Datalogics.PDFL;
  *
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 namespace ExtractCJKTextByPatternMatch
 {

--- a/Text/ExtractTextByPatternMatch/ExtractTextByPatternMatch.cs
+++ b/Text/ExtractTextByPatternMatch/ExtractTextByPatternMatch.cs
@@ -8,9 +8,6 @@ using Datalogics.PDFL;
  *
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 namespace ExtractTextByPatternMatch
 {

--- a/Text/ExtractTextByRegion/ExtractTextByRegion.cs
+++ b/Text/ExtractTextByRegion/ExtractTextByRegion.cs
@@ -9,9 +9,6 @@ using ExtractTextNameSpace;
  *
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 namespace ExtractTextByRegion
 {

--- a/Text/ExtractTextFromAnnotations/ExtractTextFromAnnotations.cs
+++ b/Text/ExtractTextFromAnnotations/ExtractTextFromAnnotations.cs
@@ -11,9 +11,6 @@ using ExtractTextNameSpace;
  *
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/.
- *
  */
 namespace ExtractTextFromAnnotations
 {

--- a/Text/ExtractTextFromMultiRegions/ExtractTextFromMultiRegions.cs
+++ b/Text/ExtractTextFromMultiRegions/ExtractTextFromMultiRegions.cs
@@ -10,9 +10,6 @@ using ExtractTextNameSpace;
  * 
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 namespace ExtractTextFromMultiRegions
 {

--- a/Text/ExtractTextPreservingStyleAndPositionInfo/ExtractTextPreservingStyleAndPositionInfo.cs
+++ b/Text/ExtractTextPreservingStyleAndPositionInfo/ExtractTextPreservingStyleAndPositionInfo.cs
@@ -12,9 +12,6 @@ using ExtractTextNameSpace;
  *
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/.
- *
  */
 namespace ExtractTextPreservingStyleAndPositionInfo
 {

--- a/Text/ListWords/ListWords.cs
+++ b/Text/ListWords/ListWords.cs
@@ -6,14 +6,8 @@ using Datalogics.PDFL;
  * 
  * This sample lists the text for the words in a PDF document.
  * 
- * For more detail see the description of the List sample programs, and ListWords, on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/listing-information-about-values-and-objects-in-pdf-files
  * 
- * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace ListWords

--- a/Text/RegexExtractText/RegexExtractText.cs
+++ b/Text/RegexExtractText/RegexExtractText.cs
@@ -9,10 +9,7 @@ using Datalogics.PDFL;
  * that matches a user-supplied regular expression. The output is a JSON file that
  * has the match information.
  * 
- * Copyright (c) 2021, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2021-2023, Datalogics, Inc. All rights reserved.
  *
  */
 

--- a/Text/RegexTextSearch/RegexTextSearch.cs
+++ b/Text/RegexTextSearch/RegexTextSearch.cs
@@ -7,10 +7,7 @@ using Datalogics.PDFL;
  * document that match a user-supplied regular expression. When the sample finds the text it
  * highlights each match and saves the file as an output document.
  * 
- * Copyright (c) 2007-2021, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace RegexTextSearch

--- a/Text/TextExtract/TextExtract.cs
+++ b/Text/TextExtract/TextExtract.cs
@@ -11,10 +11,7 @@ using Datalogics.PDFL;
  * PDF file is tagged or untagged. Tagging is used to make PDF files accessible
  * to the blind or to people with vision problems. 
  * 
- * Copyright (c) 2007-2020, Datalogics, Inc. All rights reserved.
- *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
+ * Copyright (c) 2007-2023, Datalogics, Inc. All rights reserved.
  *
  */
 namespace TextExtract

--- a/_Common/ExtractText.cs
+++ b/_Common/ExtractText.cs
@@ -12,9 +12,6 @@ using Datalogics.PDFL;
  *
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
- * For complete copyright information, refer to:
- * http://dev.datalogics.com/adobe-pdf-library/license-for-downloaded-pdf-samples/
- *
  */
 
 namespace ExtractTextNameSpace


### PR DESCRIPTION
Remove devsite links, all the information is now in this github repository for the samples.

Remove extra DL copyright devsite link which was uncessary.

Update through copyright of all samples.

Some recently created samples needed a through copyright, not just the current year.

Remove asterisks from markdown which had no effect.