### PR TITLE
Add deployment scripts.

### DIFF
--- a/Deployment_Publish_Scripts/Linux/PublishToLinux.sh
+++ b/Deployment_Publish_Scripts/Linux/PublishToLinux.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This is a simple script to illustrate how to publish the dependencies of PDFL for .NET.
+# You should first publish your .NET application to copy the PDFL .NET Class library and other .NET dependencies, e.g.:
+# dotnet publish ./MyApplication.csproj
+
+echo Copy PDFL libraries
+cp ./*.so* ./publish
+
+echo Copy Plugin libraries
+cp ./*.ppi ./publish
+
+echo Copy Tesseract Data which is needed for OCR usage, if you aren't using OCR you don't need this.
+cp -rp ./tessdata4 ./publish
+
+echo Copy Resources which contains things needed by PDFL for dealing with Fonts, CMaps, and Color Profiles for example
+cp -rp ./Resources ./publish

--- a/Deployment_Publish_Scripts/Linux/PublishToMac.sh
+++ b/Deployment_Publish_Scripts/Linux/PublishToMac.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This is a simple script to illustrate how to publish the dependencies of PDFL for .NET.
+# You should first publish your .NET application to copy the PDFL .NET Class library and other .NET dependencies, e.g.:
+# dotnet publish ./MyApplication.csproj
+
+echo Copy Tesseract Data which is needed for OCR usage, if you aren't using OCR you don't need this.
+cp -rp ./tessdata4 ./publish
+
+echo Copy Mac dependencies, upon deployment you need to decompress this archive
+cp ./macOS_Dependencies.zip ./publish
+
+echo Copy Resources which contains things needed by PDFL for dealing with Fonts, CMaps, and Color Profiles for example
+cp -rp ./Resources ./publish

--- a/Deployment_Publish_Scripts/Linux/PublishToMacARM.sh
+++ b/Deployment_Publish_Scripts/Linux/PublishToMacARM.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This is a simple script to illustrate how to publish the dependencies of PDFL for .NET.
+# You should first publish your .NET application to copy the PDFL .NET Class library and other .NET dependencies, e.g.:
+# dotnet publish ./MyApplication.csproj
+
+echo Copy Tesseract Data which is needed for OCR usage, if you aren't using OCR you don't need this.
+cp -rp ./tessdata4 ./publish
+
+echo Copy Mac ARM dependencies, upon deployment you need to decompress this archive
+cp ./MacARM_Dependencies.zip ./publish
+
+echo Copy Resources which contains things needed by PDFL for dealing with Fonts, CMaps, and Color Profiles for example
+cp -rp ./Resources ./publish

--- a/Deployment_Publish_Scripts/Linux/PublishToWindows.sh
+++ b/Deployment_Publish_Scripts/Linux/PublishToWindows.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This is a simple script to illustrate how to publish the dependencies of PDFL for .NET.
+# You should first publish your .NET application to copy the PDFL .NET Class library and other .NET dependencies, e.g.:
+# dotnet publish ./MyApplication.csproj
+
+echo Copy Tesseract Data which is needed for OCR usage, if you aren't using OCR you don't need this.
+cp -rp ./tessdata4 ./publish
+
+echo Copy Windows dependencies, upon deployment you need to decompress this archive
+cp ./Windows_Dependencies.zip ./publish
+
+echo Copy Resources which contains things needed by PDFL for dealing with Fonts, CMaps, and Color Profiles for example
+cp -rp ./Resources ./publish

--- a/Deployment_Publish_Scripts/Mac/PublishToLinux.sh
+++ b/Deployment_Publish_Scripts/Mac/PublishToLinux.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This is a simple script to illustrate how to publish the dependencies of PDFL for .NET.
+# You should first publish your .NET application to copy the PDFL .NET Class library and other .NET dependencies, e.g.:
+# dotnet publish ./MyApplication.csproj
+
+# Make sure the directory is there, so the following commands work
+mkdir -p publish
+
+rsync="rsync -aEq --delete"
+
+echo Copy Tesseract Data which is needed for OCR usage, if you aren't using OCR you don't need this.
+$rsync ./tessdata4/ ./publish/tessdata4/
+
+echo Copy Linux dependencies, upon deployment you need to decompress this archive
+cp -a ./Linux_Dependencies.tar.gz ./publish
+
+echo Copy Resources which contains things needed by PDFL for dealing with Fonts, CMaps, and Color Profiles for example
+$rsync ./Resources/ ./publish/Resources/

--- a/Deployment_Publish_Scripts/Mac/PublishToMac.sh
+++ b/Deployment_Publish_Scripts/Mac/PublishToMac.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This is a simple script to illustrate how to publish the dependencies of PDFL for .NET.
+# You should first publish your .NET application to copy the PDFL .NET Class library and other .NET dependencies, e.g.:
+# dotnet publish ./MyApplication.csproj
+
+# Make sure the directory is there, so the following commands work
+mkdir -p publish
+
+rsync="rsync -aEq --delete"
+
+echo Copy PDFL libraries
+cp -a *.dylib ./publish
+
+echo Copy PDFL Frameworks and Plugins
+for dir in *.framework *.ppi
+do
+    $rsync $dir/ publish/$dir/
+done
+
+echo Copy Tesseract Data which is needed for OCR usage, if you aren't using OCR you don't need this.
+$rsync ./tessdata4/ ./publish/tessdata4/
+
+echo Copy Resources which contains things needed by PDFL for dealing with Fonts, CMaps, and Color Profiles for example
+$rsync ./Resources/ ./publish/Resources/

--- a/Deployment_Publish_Scripts/Mac/PublishToWindows.sh
+++ b/Deployment_Publish_Scripts/Mac/PublishToWindows.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This is a simple script to illustrate how to publish the dependencies of PDFL for .NET.
+# You should first publish your .NET application to copy the PDFL .NET Class library and other .NET dependencies, e.g.:
+# dotnet publish ./MyApplication.csproj
+
+# Make sure the directory is there, so the following commands work
+mkdir -p publish
+
+rsync="rsync -aEq --delete"
+
+echo Copy Tesseract Data which is needed for OCR usage, if you aren't using OCR you don't need this.
+$rsync ./tessdata4/ ./publish/tessdata4/
+
+echo Copy Windows dependencies, upon deployment you need to decompress this archive
+cp -a ./Windows_Dependencies.zip ./publish
+
+echo Copy Resources which contains things needed by PDFL for dealing with Fonts, CMaps, and Color Profiles for example
+$rsync ./Resources/ ./publish/Resources/

--- a/Deployment_Publish_Scripts/Windows/PublishToLinux.bat
+++ b/Deployment_Publish_Scripts/Windows/PublishToLinux.bat
@@ -1,0 +1,12 @@
+REM This is a simple script to illustrate how to publish the dependencies of PDFL for .NET.
+REM You should first publish your .NET application to copy the PDFL .NET Class library and other .NET dependencies, e.g.:
+REM dotnet publish ./MyApplication.csproj
+
+echo Copy Tesseract Data which is needed for OCR usage, if you aren't using OCR you don't need this.
+xcopy "./tessdata4" "./publish/tessdata4" /i /y
+
+echo Copy Linux dependencies, upon deployment you need to decompress this archive
+xcopy "Linux_Dependencies.tar.gz" "./publish" /y
+
+echo Copy Resources which contains things needed by PDFL for dealing with Fonts, CMaps, and Color Profiles for example
+xcopy ".\Resources\*" ".\publish\Resources" /i /s /y

--- a/Deployment_Publish_Scripts/Windows/PublishToMac.bat
+++ b/Deployment_Publish_Scripts/Windows/PublishToMac.bat
@@ -1,0 +1,12 @@
+REM This is a simple script to illustrate how to publish the dependencies of PDFL for .NET.
+REM You should first publish your .NET application to copy the PDFL .NET Class library and other .NET dependencies, e.g.:
+REM dotnet publish ./MyApplication.csproj
+
+echo Copy Tesseract Data which is needed for OCR usage, if you aren't using OCR you don't need this.
+xcopy "./tessdata4" "./publish/tessdata4" /i /y
+
+echo Copy Mac dependencies, upon deployment you need to decompress this archive
+xcopy "macOS_Dependencies.zip" "./publish" /y
+
+echo Copy Resources which contains things needed by PDFL for dealing with Fonts, CMaps, and Color Profiles for example
+xcopy ".\Resources\*" ".\publish\Resources" /i /s /y

--- a/Deployment_Publish_Scripts/Windows/PublishToMacARM.bat
+++ b/Deployment_Publish_Scripts/Windows/PublishToMacARM.bat
@@ -1,0 +1,12 @@
+REM This is a simple script to illustrate how to publish the dependencies of PDFL for .NET.
+REM You should first publish your .NET application to copy the PDFL .NET Class library and other .NET dependencies, e.g.:
+REM dotnet publish ./MyApplication.csproj
+
+echo Copy Tesseract Data which is needed for OCR usage, if you aren't using OCR you don't need this.
+xcopy "./tessdata4" "./publish/tessdata4" /i /y
+
+echo Copy Mac ARM dependencies, upon deployment you need to decompress this archive
+xcopy "MacARM_Dependencies.zip" "./publish" /y
+
+echo Copy Resources which contains things needed by PDFL for dealing with Fonts, CMaps, and Color Profiles for example
+xcopy ".\Resources\*" ".\publish\Resources" /i /s /y

--- a/Deployment_Publish_Scripts/Windows/PublishToWindows.bat
+++ b/Deployment_Publish_Scripts/Windows/PublishToWindows.bat
@@ -1,0 +1,15 @@
+REM This is a simple script to illustrate how to publish the dependencies of PDFL for .NET.
+REM You should first publish your .NET application to copy the PDFL .NET Class library and other .NET dependencies, e.g.:
+REM dotnet publish ./MyApplication.csproj
+
+echo Copy PDFL .dll's
+xcopy "*.dll" "./publish" /y
+
+echo Copy Plugin dll's
+xcopy "*.ppi" "./publish" /y
+
+echo Copy Tesseract Data which is needed for OCR usage, if you aren't using OCR you don't need this.
+xcopy "./tessdata4" "./publish/tessdata4" /i /y
+
+echo Copy Resources which contains things needed by PDFL for dealing with Fonts, CMaps, and Color Profiles for example
+xcopy ".\Resources\*" ".\publish\Resources" /i /s /y


### PR DESCRIPTION
Add deployment scripts used as a guide for how to deploy your application.

(These are included in the PDF library traditional installer but were _missed_ as part of the new samples repository)

The paths used are meant as examples of wherever you have your local resources _actually_ stored relative to the project.
