### PR TITLE
Modify the docs.datalogics.com URLs to their new locations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Datalogics Adobe PDF Library](https://raw.github.com/datalogics/dl-icons/develop/DLBanner_Nuget.png)
 
-[Documentation](https://docs.datalogics.com/DotNet/index.html) &nbsp;|&nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp; [Release Notes](https://docs.datalogics.com/Release_Notes.html) &nbsp; | &nbsp;[Homepage](https://www.datalogics.com)
+[Documentation](https://docs.datalogics.com/apdfl18/DotNet/index.html) &nbsp;|&nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp; [Release Notes](https://docs.datalogics.com/apdfl18/Release_Notes.html) &nbsp; | &nbsp;[Homepage](https://www.datalogics.com)
 
 [![Download a Free Trial on NuGet](https://img.shields.io/nuget/dt/Adobe.PDF.Library.LM.NET?color=blue&label=APDFL%20.NET%20Free%20Trial&logo=NuGet&style=plastic)](https://www.nuget.org/packages/Adobe.PDF.Library.LM.NET)
 


### PR DESCRIPTION
Modify the docs.datalogics.com URLs to their new locations.
Use new location for doc links created in
[datalogics.github.io pull request 21](https://github.com/datalogics/datalogics.github.io/pull/21)
