### PR TITLE
Add OutputPreview sample.

### DIFF
--- a/Images/OutputPreview/OutputPreview.cs
+++ b/Images/OutputPreview/OutputPreview.cs
@@ -14,6 +14,20 @@ namespace OutputPreview
 {
     class OutputPreview
     {
+        static string CreateOutputFileName(List<string> colorants)
+        {
+            string outputFileName = "OutputPreview_";
+
+            foreach(string colorant in colorants)
+            {
+                outputFileName += colorant + "_";
+            }
+
+            outputFileName += ".tiff";
+
+            return outputFileName;
+        }
+
         static void Main(string[] args)
         {
             Console.WriteLine("OutputPreview Sample:");
@@ -69,11 +83,11 @@ namespace OutputPreview
                         // Create Output Preview images using the Specified Colorants
                         Datalogics.PDFL.Image image = pg.GetOutputPreviewImage(pg.CropBox, pip, colorants);
 
-                        image.Save(String.Format("OutputPreview_{0}_{1}.tiff", colorantsToUse[0], colorantsToUse[1]), ImageType.TIFF);
+                        image.Save(CreateOutputFileName(colorantsToUse), ImageType.TIFF);
 
                         Datalogics.PDFL.Image image2 = pg.GetOutputPreviewImage(pg.CropBox, pip, colorants2);
 
-                        image2.Save(String.Format("OutputPreview_{0}_{1}.tiff", colorantsToUse2[0], colorantsToUse2[1]), ImageType.TIFF);
+                        image2.Save(CreateOutputFileName(colorantsToUse2), ImageType.TIFF);
                     }
                 }
             }

--- a/Images/OutputPreview/OutputPreview.cs
+++ b/Images/OutputPreview/OutputPreview.cs
@@ -1,0 +1,82 @@
+using Datalogics.PDFL;
+using System;
+using System.Collections.Generic;
+
+/*
+ * This sample demonstrates creating an Output Preview Image which is used during Soft Proofing prior to printing to visualize combining different Colorants.
+ *
+ * 
+ * Copyright (c)2023, Datalogics, Inc. All rights reserved.
+ *
+ */
+
+namespace OutputPreview
+{
+    class OutputPreview
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("OutputPreview Sample:");
+
+            String sInput = Library.ResourceDirectory + "Sample_Input/spotcolors1.pdf";
+
+            // Here you specify the Colorant names of interest
+            List<String> colorantsToUse = new List<string>() { "Yellow", "Black" };
+
+            List<String> colorantsToUse2 = new List<string>() { "PANTONE 554 CVC", "PANTONE 814 2X CVC", "PANTONE 185 2X CVC" };
+
+            using (Library lib = new Library())
+            {
+                using (Document doc = new Document(sInput))
+                {
+                    using (Page pg = doc.GetPage(0))
+                    {
+                        // Get all inks that are present on the page
+                        List<Ink> inks = (List<Ink>)pg.ListInks();
+
+                        List<SeparationColorSpace> colorants = new List<SeparationColorSpace>();
+
+                        foreach (Ink theInk in inks)
+                        {
+                            foreach (String theColorant in colorantsToUse)
+                            {
+                                if (theInk.ColorantName == theColorant)
+                                {
+                                    colorants.Add(new SeparationColorSpace(pg, theInk));
+                                }
+                            }
+                        }
+
+                        List<SeparationColorSpace> colorants2 = new List<SeparationColorSpace>();
+
+                        foreach (Ink theInk in inks)
+                        {
+                            foreach (String theColorant in colorantsToUse2)
+                            {
+                                if (theInk.ColorantName == theColorant)
+                                {
+                                    colorants2.Add(new SeparationColorSpace(pg, theInk));
+                                }
+                            }
+                        }
+
+                        PageImageParams pip = new PageImageParams();
+                        pip.HorizontalResolution = 300;
+                        pip.VerticalResolution = 300;
+
+                        ImageSaveParams sp = new ImageSaveParams();
+
+                        // Create Output Preview images using the Specified Colorants
+                        Datalogics.PDFL.Image image = pg.GetOutputPreviewImage(pg.CropBox, pip, colorants);
+
+                        image.Save(String.Format("OutputPreview_{0}_{1}.tiff", colorantsToUse[0], colorantsToUse[1]), ImageType.TIFF);
+
+                        Datalogics.PDFL.Image image2 = pg.GetOutputPreviewImage(pg.CropBox, pip, colorants2);
+
+                        image2.Save(String.Format("OutputPreview_{0}_{1}.tiff", colorantsToUse2[0], colorantsToUse2[1]), ImageType.TIFF);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Images/OutputPreview/OutputPreview.csproj
+++ b/Images/OutputPreview/OutputPreview.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+  </ItemGroup>
+
+</Project>

--- a/Images/README.md
+++ b/Images/README.md
@@ -34,5 +34,8 @@ Explores the content of PDF pages and when images are found they are resampled t
 ## ***ImageSoftMask***
 Adds an image file to be placed on a PDF page and adds another image file to use as its SoftMask image.
 
+## ***OutputPreview***
+Creates an Output Preview Image which is used during Soft Proofing prior to printing to visualize combining different Colorants.
+
 ## ***RasterizePage***
 Rasterizes the first page of a PDF document.


### PR DESCRIPTION
To demonstrate generating an OutputPreview image from a PDF page, this is typically used during Soft Proofing prior to final print.