### PR TITLE
Change to SkiaSharp 2.88.5

### DIFF
--- a/Display/DisplayPDF/DisplayPDF.csproj
+++ b/Display/DisplayPDF/DisplayPDF.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-    <PackageReference Include="SkiaSharp" Version="2.88.2" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Images/DrawSeparations/DrawSeparations.csproj
+++ b/Images/DrawSeparations/DrawSeparations.csproj
@@ -9,11 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-    <PackageReference Include="SkiaSharp" Version="2.88.*" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.*" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.*" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.5" />
   </ItemGroup>
 
 </Project>

--- a/Images/DrawToBitmap/DrawToBitmap.csproj
+++ b/Images/DrawToBitmap/DrawToBitmap.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
-    <PackageReference Include="SkiaSharp" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.*" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.*" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.5" />
   </ItemGroup>
 
 </Project>

--- a/Images/ImageExtraction/ImageExtraction.csproj
+++ b/Images/ImageExtraction/ImageExtraction.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
-    <PackageReference Include="SkiaSharp" Version="2.88.*" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.*" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.*" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.5" />
   </ItemGroup>
 
 </Project>

--- a/Images/ImageFromStream/ImageFromStream.csproj
+++ b/Images/ImageFromStream/ImageFromStream.csproj
@@ -9,7 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
-    <PackageReference Include="SkiaSharp" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.5" />
   </ItemGroup>
 
 </Project>

--- a/Images/RasterizePage/RasterizePage.csproj
+++ b/Images/RasterizePage/RasterizePage.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
-    <PackageReference Include="SkiaSharp" Version="2.88.*" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.*" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.*" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
It appears SkiaSharp 2.88.6 is problematic and is the latest version. Let's target the previous version.  Unless there's major changes we normally wouldn't need to worry about keeping this up to date.

Remove an unused package.