### PR TITLE
Update SkiaSharp to latest.

### DIFF
--- a/Display/DisplayPDF/DisplayPDF.csproj
+++ b/Display/DisplayPDF/DisplayPDF.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-    <PackageReference Include="SkiaSharp" Version="2.88.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Images/DrawSeparations/DrawSeparations.csproj
+++ b/Images/DrawSeparations/DrawSeparations.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
-    <PackageReference Include="SkiaSharp" Version="2.88.5" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.5" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.5" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.*" />
   </ItemGroup>
 
 </Project>

--- a/Images/DrawToBitmap/DrawToBitmap.cs
+++ b/Images/DrawToBitmap/DrawToBitmap.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using SkiaSharp;
 using Datalogics.PDFL;
 using System.IO;
+using System.Runtime.InteropServices;
 
 /*
  *
@@ -91,8 +92,14 @@ namespace DrawToBitmap
         /// <param name="nameSuffix">the suffix for saved file.</param>
         private static void SaveBitmap(SKBitmap sKBitmap, string nameSuffix)
         {
-            using (FileStream f = File.OpenWrite(String.Format("DrawTo{0}.jpg", nameSuffix)))
-                sKBitmap.Encode(SKEncodedImageFormat.Jpeg, 100).SaveTo(f);
+            //Known issue in JPEG encoding in SkiaSharp v2.88.6: https://github.com/mono/SkiaSharp/issues/2643 on non-Windows.
+            //Previous versions have known vulnerability.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                using (FileStream f = File.OpenWrite(String.Format("DrawTo{0}.jpg", nameSuffix)))
+                    sKBitmap.Encode(SKEncodedImageFormat.Jpeg, 100).SaveTo(f);
+            }
+
             using (FileStream f = File.OpenWrite(String.Format("DrawTo{0}.png", nameSuffix)))
                 sKBitmap.Encode(SKEncodedImageFormat.Png, 100).SaveTo(f);
         }

--- a/Images/DrawToBitmap/DrawToBitmap.csproj
+++ b/Images/DrawToBitmap/DrawToBitmap.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
-    <PackageReference Include="SkiaSharp" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp" Version="2.88.*" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.*" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.5" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.*" />
   </ItemGroup>
 
 </Project>

--- a/Images/ImageExtraction/ImageExtraction.csproj
+++ b/Images/ImageExtraction/ImageExtraction.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
-    <PackageReference Include="SkiaSharp" Version="2.88.5" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.5" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.5" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.*" />
   </ItemGroup>
 
 </Project>

--- a/Images/ImageFromStream/ImageFromStream.cs
+++ b/Images/ImageFromStream/ImageFromStream.cs
@@ -1,11 +1,12 @@
 using System;
+using System.Runtime.InteropServices;
 using Datalogics.PDFL;
 using SkiaSharp;
 
 /*
  * 
  * This sample program searches through the PDF file that you select and identifies drawings,
- * diagrams and photographs from the System.IO.Streams. 
+ * diagrams and photographs from the System.IO.Streams.
  * 
  * A stream is a string of bytes of any length, embedded in a PDF document with a dictionary
  * that is used to interpret the values in the stream.
@@ -46,7 +47,7 @@ namespace ImageFromStream
                 Console.WriteLine("using bitmap input " + bitmapInput + " and jpeg input " + jpegInput +
                                   ". Writing to output " + docOutput);
 
-                // Create a .NET MemoryStream object.
+                // Create a MemoryStream object.
                 // A MemoryStream is used here for demonstration only, but the technique
                 // works just as well for other streams which support seeking.
                 using (System.IO.MemoryStream BitmapStream = new System.IO.MemoryStream())
@@ -54,10 +55,9 @@ namespace ImageFromStream
                     // Load a bitmap image into the MemoryStream.
                     using (SKBitmap BitmapImage = SKBitmap.FromImage(SKImage.FromEncodedData(bitmapInput)))
                     {
-
                         BitmapImage.Encode(SKEncodedImageFormat.Png, 100).SaveTo(BitmapStream);
 
-                        // Reset the MemoryStream's seek position before handing it to the PDFL API, 
+                        // Reset the MemoryStream's seek position before handing it to the PDFL API,
                         // which expects the seek position to be at the beginning of the stream.
                         BitmapStream.Seek(0, System.IO.SeekOrigin.Begin);
 
@@ -69,28 +69,39 @@ namespace ImageFromStream
 
                         // The following demonstrates reading an image from a Stream and placing it into a document.
                         // First, create a new Document and add a Page to it.
-                        Document doc = new Document();
-                        doc.CreatePage(Document.BeforeFirstPage, new Rect(0, 0, 612, 792));
-
-                        // Create a new MemoryStream for a new image file.
-                        using (System.IO.MemoryStream JpegStream = new System.IO.MemoryStream())
+                        using (Document doc = new Document())
                         {
-                            // Load a JPEG image into the MemoryStream.
-                            using (SKImage JpegImage = SKImage.FromEncodedData(jpegInput))
+                            doc.CreatePage(Document.BeforeFirstPage, new Rect(0, 0, 612, 792));
+
+                            // Create a new MemoryStream for a new image file.
+                            using (System.IO.MemoryStream outputImageStream = new System.IO.MemoryStream())
                             {
-                                JpegImage.Encode(SKEncodedImageFormat.Jpeg, 100).SaveTo(JpegStream);
+                                // Load a JPEG image into the MemoryStream.
+                                using (SKImage inputImage = SKImage.FromEncodedData(jpegInput))
+                                {
+                                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                                    {
+                                        inputImage.Encode(SKEncodedImageFormat.Jpeg, 100).SaveTo(outputImageStream);
+                                    }
+                                    else
+                                    {
+                                        //Known issue in JPEG encoding in SkiaSharp v2.88.6: https://github.com/mono/SkiaSharp/issues/2643
+                                        //Previous versions have known vulnerability, so use PNG instead.
+                                        inputImage.Encode(SKEncodedImageFormat.Png, 100).SaveTo(outputImageStream);
+                                    }
 
-                                // An alternative method for resetting the MemoryStream's seek position.
-                                JpegStream.Position = 0;
+                                    // An alternative method for resetting the MemoryStream's seek position.
+                                    outputImageStream.Position = 0;
 
-                                // Create the PDFL Image object and put it in the Document.
-                                // Since the image will be placed in a Document, use the constructor with the optional 
-                                // Document parameter to optimize data usage for this image within the Document.
-                                Datalogics.PDFL.Image PDFLJpegImage = new Datalogics.PDFL.Image(JpegStream, doc);
-                                Page pg = doc.GetPage(0);
-                                pg.Content.AddElement(PDFLJpegImage);
-                                pg.UpdateContent();
-                                doc.Save(SaveFlags.Full, docOutput);
+                                    // Create the PDFL Image object and put it in the Document.
+                                    // Since the image will be placed in a Document, use the constructor with the optional
+                                    // Document parameter to optimize data usage for this image within the Document.
+                                    Datalogics.PDFL.Image PDFLJpegImage = new Datalogics.PDFL.Image(outputImageStream, doc);
+                                    Page pg = doc.GetPage(0);
+                                    pg.Content.AddElement(PDFLJpegImage);
+                                    pg.UpdateContent();
+                                    doc.Save(SaveFlags.Full, docOutput);
+                                }
                             }
                         }
                     }

--- a/Images/ImageFromStream/ImageFromStream.csproj
+++ b/Images/ImageFromStream/ImageFromStream.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
-    <PackageReference Include="SkiaSharp" Version="2.88.5" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.5" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.5" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.*" />
   </ItemGroup>
 
 </Project>

--- a/Images/RasterizePage/RasterizePage.csproj
+++ b/Images/RasterizePage/RasterizePage.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
-    <PackageReference Include="SkiaSharp" Version="2.88.5" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.5" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.5" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.5" />
+    <PackageReference Include="SkiaSharp" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.*" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Previously we specified SkiaSharp v2.88.5 because of a recent regression with JPEG output on non-windows.

But the older versions have a known vulnerability so let's go back to the using the latest version and just use PNG instead to avoid the bug where needed and add an explanatory comment.

Remove SkiaSharp from DisplayPDF sample which didn't actually use it.