### PR TITLE
Run the AddQRCode sample in CI

### DIFF
--- a/.github/workflows/test-dotnet-samples.yml
+++ b/.github/workflows/test-dotnet-samples.yml
@@ -2,8 +2,13 @@ name: test-samples
 
 on:
     pull_request:
+      branches:
+        - develop
+        - main
     push:
-        branches: [ develop, main ]
+      branches:
+        - develop
+        - main
 
 env:
     DOTNET_VERSION: '6.x'
@@ -42,6 +47,7 @@ jobs:
               'ContentCreation/WriteNChannelTiff/',
               'ContentModification/Action/',
               'ContentModification/AddCollection/',
+              'ContentModification/AddQRCode/',
               'ContentModification/ChangeLayerConfiguration/',
               'ContentModification/ChangeLinkColors/',
               'ContentModification/CreateLayer/',


### PR DESCRIPTION
Let's ensure that we run the newly added AddQRCode sample in CI. Also, specify the base branches on which to run CI.

NOTE: The macOS samples seem to be failing to activate because of the GitHub Actions runners, not due to our license activation logic.