### PR TITLE
Use final package version

### DIFF
--- a/Forms/ConvertXFAToAcroForms/ConvertXFAToAcroForms.csproj
+++ b/Forms/ConvertXFAToAcroForms/ConvertXFAToAcroForms.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.FormsExtension.LM.NET" Version="1.*" />
+    <PackageReference Include="Adobe.PDF.Library.FormsExtension.LM.NET" Version="18.*" />
   </ItemGroup>
 
 </Project>

--- a/Forms/ExportFormsData/ExportFormsData.csproj
+++ b/Forms/ExportFormsData/ExportFormsData.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.FormsExtension.LM.NET" Version="1.*" />
+    <PackageReference Include="Adobe.PDF.Library.FormsExtension.LM.NET" Version="18.*" />
   </ItemGroup>
 
 </Project>

--- a/Forms/FlattenForms/FlattenForms.csproj
+++ b/Forms/FlattenForms/FlattenForms.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.FormsExtension.LM.NET" Version="1.*" />
+    <PackageReference Include="Adobe.PDF.Library.FormsExtension.LM.NET" Version="18.*" />
   </ItemGroup>
 
 </Project>

--- a/Forms/ImportFormsData/ImportFormsData.csproj
+++ b/Forms/ImportFormsData/ImportFormsData.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.FormsExtension.LM.NET" Version="1.*" />
+    <PackageReference Include="Adobe.PDF.Library.FormsExtension.LM.NET" Version="18.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We will keep the consistent 18.val.val used on the standard APDFL package