### PR TITLE
Samples CI Testing Adjustments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -148,6 +148,22 @@ pipeline {
                             }
                         }
                     }
+                    stage('Clean Samples After Run') {
+                        steps {
+                            echo "Clean ${NODE}"
+                            script {
+                                if (isUnix()) {
+                                    sh """. ${ENV_LOC[NODE]}/bin/activate
+                                          invoke clean-samples
+                                    """
+                                } else {
+                                    bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
+                                          invoke clean-samples
+                                    """
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/tasks.py
+++ b/tasks.py
@@ -143,17 +143,17 @@ def build_samples(ctx, pkg_name='Adobe.PDF.Library.NET'):
                     ctx.run(f'dotnet build '
                             '--source https://api.nuget.org/v3/index.json '
                             '--source /Volumes/raid/products/released/APDFL/nuget/DotNET/for_apdfl_18.0.5Plus/approved/current '
-                            '--source /Volumes/raid/products/released/APDFL/nuget/SampleInputFile/for_apdfl_18.0.5Plus/approved/current ')
+                            '--source /Volumes/raid/products/released/APDFL/nuget/SampleInputFile/for_apdfl_18.0.4Plus/approved/current ')
                 elif platform.system() == 'Windows':
                     ctx.run(f'dotnet build '
                             '--source https://api.nuget.org/v3/index.json '
                             '--source \\\\ivy\\raid\\products\\released\\APDFL\\nuget\\DotNET\\for_apdfl_18.0.5Plus\\approved\\current '
-                            '--source \\\\ivy\\raid\\products\\released\\APDFL\\nuget\\SampleInputFile\\for_apdfl_18.0.5Plus\\approved\\current ')
+                            '--source \\\\ivy\\raid\\products\\released\\APDFL\\nuget\\SampleInputFile\\for_apdfl_18.0.4Plus\\approved\\current ')
                 else:
                     ctx.run(f'dotnet build '
                             '--source https://api.nuget.org/v3/index.json '
                             '--source /raid/products/released/APDFL/nuget/DotNET/for_apdfl_18.0.5Plus/approved/current '
-                            '--source /raid/products/released/APDFL/nuget/SampleInputFile/for_apdfl_18.0.5Plus/approved/current ')
+                            '--source /raid/products/released/APDFL/nuget/SampleInputFile/for_apdfl_18.0.4Plus/approved/current ')
 
 
 @task()

--- a/tasks.py
+++ b/tasks.py
@@ -167,6 +167,8 @@ def run_samples(ctx):
         if platform.system() == 'Darwin' and ('ConvertToOffice' in sample or 'CreateDocFromXPS' in sample):
             print(f'{sample} not available on this OS')
             continue
+        elif platform.system() == 'Linux' and 'ConvertToOffice' in sample:
+            continue
         else:
             with ctx.cd(full_path):
                 sample_name = os.path.basename(os.path.dirname(full_path))

--- a/tasks.py
+++ b/tasks.py
@@ -142,18 +142,18 @@ def build_samples(ctx, pkg_name='Adobe.PDF.Library.NET'):
                 if platform.system() == 'Darwin':
                     ctx.run(f'dotnet build '
                             '--source https://api.nuget.org/v3/index.json '
-                            '--source /Volumes/raid/products/released/APDFL/nuget/DotNET/for_apdfl_18.0.4Plus/approved/current '
-                            '--source /Volumes/raid/products/released/APDFL/nuget/SampleInputFile/for_apdfl_18.0.4Plus/approved/current ')
+                            '--source /Volumes/raid/products/released/APDFL/nuget/DotNET/for_apdfl_18.0.5Plus/approved/current '
+                            '--source /Volumes/raid/products/released/APDFL/nuget/SampleInputFile/for_apdfl_18.0.5Plus/approved/current ')
                 elif platform.system() == 'Windows':
                     ctx.run(f'dotnet build '
                             '--source https://api.nuget.org/v3/index.json '
-                            '--source \\\\ivy\\raid\\products\\released\\APDFL\\nuget\\DotNET\\for_apdfl_18.0.4Plus\\approved\\current '
-                            '--source \\\\ivy\\raid\\products\\released\\APDFL\\nuget\\SampleInputFile\\for_apdfl_18.0.4Plus\\approved\\current ')
+                            '--source \\\\ivy\\raid\\products\\released\\APDFL\\nuget\\DotNET\\for_apdfl_18.0.5Plus\\approved\\current '
+                            '--source \\\\ivy\\raid\\products\\released\\APDFL\\nuget\\SampleInputFile\\for_apdfl_18.0.5Plus\\approved\\current ')
                 else:
                     ctx.run(f'dotnet build '
                             '--source https://api.nuget.org/v3/index.json '
-                            '--source /raid/products/released/APDFL/nuget/DotNET/for_apdfl_18.0.4Plus/approved/current '
-                            '--source /raid/products/released/APDFL/nuget/SampleInputFile/for_apdfl_18.0.4Plus/approved/current ')
+                            '--source /raid/products/released/APDFL/nuget/DotNET/for_apdfl_18.0.5Plus/approved/current '
+                            '--source /raid/products/released/APDFL/nuget/SampleInputFile/for_apdfl_18.0.5Plus/approved/current ')
 
 
 @task()


### PR DESCRIPTION
Clean the build area after running the samples

skip the ConvertToOffice samples while the build machines are being upgraded

Update to latest 18.0.5 packages