### PR TITLE
Add logic to test the nuget-builder packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,9 +13,10 @@ pipeline {
     }
     agent none
     triggers {
-        // From the doc: @midnight actually means some time between 12:00 AM and 2:59 AM.
-        // This gives us automatic spreading out of jobs, so they don't cause load spikes.
-        cron('@midnight')
+        // Run branches between 0800 and 0830, depending on a hash of the job name
+        // This means if there's more than one branch (a feature branch, maybe?), they
+        // won't all start at the same time.
+        cron(env.BRANCH_NAME == "develop" ? 'H(0-30) 6 * * *' : '')
     }
     stages {
         stage('Matrix stage') {

--- a/tasks.py
+++ b/tasks.py
@@ -123,7 +123,7 @@ def clean_samples(ctx):
             ctx.run('git checkout .')
 
 @task()
-def build_samples(ctx, pkg_name='Adobe.PDF.Library.NET', config='Release'):
+def build_samples(ctx, pkg_name='Adobe.PDF.Library.NET', config='Debug'):
     """Builds the .NET6 samples
     """
     ctx.run('invoke clean-samples')

--- a/tasks.py
+++ b/tasks.py
@@ -123,7 +123,7 @@ def clean_samples(ctx):
             ctx.run('git checkout .')
 
 @task()
-def build_samples(ctx, pkg_name='Adobe.PDF.Library.NET'):
+def build_samples(ctx, pkg_name='Adobe.PDF.Library.NET', config='Release'):
     """Builds the .NET6 samples
     """
     ctx.run('invoke clean-samples')
@@ -139,22 +139,10 @@ def build_samples(ctx, pkg_name='Adobe.PDF.Library.NET'):
                 last_directory = os.path.basename(os.path.dirname(full_path))
                 full_name = full_path + last_directory + '.csproj'
                 set_nuget_pkg_version(pathlib.Path(full_name), package=pkg_name)
-                if platform.system() == 'Darwin':
-                    ctx.run(f'dotnet build '
-                            '--source https://api.nuget.org/v3/index.json '
-                            '--source /Volumes/raid/products/released/APDFL/nuget/DotNET/for_apdfl_18.0.5Plus/approved/current '
-                            '--source /Volumes/raid/products/released/APDFL/nuget/SampleInputFile/for_apdfl_18.0.4Plus/approved/current ')
-                elif platform.system() == 'Windows':
-                    ctx.run(f'dotnet build '
-                            '--source https://api.nuget.org/v3/index.json '
-                            '--source \\\\ivy\\raid\\products\\released\\APDFL\\nuget\\DotNET\\for_apdfl_18.0.5Plus\\approved\\current '
-
-                            '--source \\\\ivy\\raid\\products\\released\\APDFL\\nuget\\SampleInputFile\\for_apdfl_18.0.4Plus\\approved\\current ')
-                else:
-                    ctx.run(f'dotnet build '
-                            '--source https://api.nuget.org/v3/index.json '
-                            '--source /raid/products/released/APDFL/nuget/DotNET/for_apdfl_18.0.5Plus/approved/current '
-                            '--source /raid/products/released/APDFL/nuget/SampleInputFile/for_apdfl_18.0.4Plus/approved/current ')
+                if config == 'Release':
+                    ctx.run(live_source_build())
+                elif config == 'Debug:':
+                    ctx.run(nightly_source_build())
 
 
 @task()
@@ -177,6 +165,38 @@ def run_samples(ctx):
                     continue
                 ctx.run(f'dotnet run --no-build')
 
+
+def live_source_build():
+    """Locations of packages that are live"""
+    if platform.system() == 'Darwin':
+        return (f'dotnet build '
+                '--source https://api.nuget.org/v3/index.json '
+                '--source /Volumes/raid/products/released/APDFL/nuget/DotNET/for_apdfl_18.0.5Plus/approved/current '
+                '--source /Volumes/raid/products/released/APDFL/nuget/SampleInputFile/for_apdfl_18.0.4Plus/approved/current ')
+    elif platform.system() == 'Windows':
+        return (f'dotnet build '
+                '--source https://api.nuget.org/v3/index.json '
+                '--source \\\\ivy\\raid\\products\\released\\APDFL\\nuget\\DotNET\\for_apdfl_18.0.5Plus\\approved\\current '
+
+                '--source \\\\ivy\\raid\\products\\released\\APDFL\\nuget\\SampleInputFile\\for_apdfl_18.0.4Plus\\approved\\current ')
+    else:
+        return (f'dotnet build '
+                '--source https://api.nuget.org/v3/index.json '
+                '--source /raid/products/released/APDFL/nuget/DotNET/for_apdfl_18.0.5Plus/approved/current '
+                '--source /raid/products/released/APDFL/nuget/SampleInputFile/for_apdfl_18.0.4Plus/approved/current ')
+
+
+def nightly_source_build():
+    """Locations of nightly packages. Note: These paths will only work on the nuget-builder build machine"""
+    if platform.system() == 'Darwin':
+        return (f'dotnet build '
+                '--source /Volumes/raid/nuget-builder-samples-test ')
+    elif platform.system() == 'Windows':
+        return (f'dotnet build '
+                '--source \\\\ivy\\raid\\nuget-builder-samples-test ')
+    else:
+        return (f'dotnet build '
+                '--source /raid/nuget-builder-samples-test ')
 
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -124,8 +124,7 @@ def clean_samples(ctx):
 
 @task()
 def build_samples(ctx, pkg_name='Adobe.PDF.Library.NET', config='Debug'):
-    """Builds the .NET6 samples
-    """
+    """Builds the .NET6 samples"""
     ctx.run('invoke clean-samples')
     for sample in samples_list:
         full_path = os.path.join(os.getcwd(), sample)
@@ -141,7 +140,7 @@ def build_samples(ctx, pkg_name='Adobe.PDF.Library.NET', config='Debug'):
                 set_nuget_pkg_version(pathlib.Path(full_name), package=pkg_name)
                 if config == 'Release':
                     ctx.run(live_source_build())
-                elif config == 'Debug:':
+                elif config == 'Debug':
                     ctx.run(nightly_source_build())
 
 
@@ -190,12 +189,15 @@ def nightly_source_build():
     """Locations of nightly packages. Note: These paths will only work on the nuget-builder build machine"""
     if platform.system() == 'Darwin':
         return (f'dotnet build '
+                '--source https://api.nuget.org/v3/index.json '
                 '--source /Volumes/raid/nuget-builder-samples-test ')
     elif platform.system() == 'Windows':
         return (f'dotnet build '
+                '--source https://api.nuget.org/v3/index.json '
                 '--source \\\\ivy\\raid\\nuget-builder-samples-test ')
     else:
         return (f'dotnet build '
+                '--source https://api.nuget.org/v3/index.json '
                 '--source /raid/nuget-builder-samples-test ')
 
 


### PR DESCRIPTION
Adds the ability to select the location of the nuget packages used to build and run the samples. 

One source is the "live" packages, and the other one is the "Debug" packages that are created as part of the nightlies