### PR TITLE
Add nuget clean cache option.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ pipeline {
         choice(name: 'PLATFORM_FILTER', choices: ['all', 'windows-dotnet-samples', 'linux-dotnet-samples', 'mac-arm-dotnet-samples', 'mac-intel-dotnet-samples','linux-arm-dotnet-samples'], description: 'Run on specific platform')
         booleanParam defaultValue: false, description: 'Completely clean the workspace before building, including the Conan cache', name: 'CLEAN_WORKSPACE'
         booleanParam defaultValue: false, description: 'Run clean-samples', name: 'DISTCLEAN'
+        booleanParam defaultValue: true, description: 'Run clean-nuget-cache', name: 'NUGETCLEAN'
     }
     options{
         buildDiscarder logRotator(artifactDaysToKeepStr: '4', artifactNumToKeepStr: '10', daysToKeepStr: '7', numToKeepStr: '10')
@@ -112,6 +113,27 @@ pipeline {
                                 } else {
                                     bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
                                           invoke clean-samples
+                                    """
+                                }
+                            }
+                        }
+                    }
+                    stage('Clean Nuget Cache') {
+                        when {
+                            expression {
+                                params.NUGETCLEAN
+                            }
+                        }
+                        steps {
+                            echo "Clean ${NODE}"
+                            script {
+                                if (isUnix()) {
+                                    sh """. ${ENV_LOC[NODE]}/bin/activate
+                                          invoke clean-nuget-cache
+                                    """
+                                } else {
+                                    bat """CALL ${ENV_LOC[NODE]}\\Scripts\\activate
+                                          invoke clean-nuget-cache
                                     """
                                 }
                             }

--- a/tasks.py
+++ b/tasks.py
@@ -124,6 +124,10 @@ def clean_samples(ctx):
             ctx.run('git checkout .')
 
 @task()
+def clean_nuget_cache(ctx):
+    ctx.run('dotnet nuget locals --clear all')
+
+@task()
 def build_samples(ctx, pkg_name='Adobe.PDF.Library.NET', config='Debug'):
     """Builds the .NET6 samples"""
     ctx.run('invoke clean-samples')


### PR DESCRIPTION
Our new OCR api was added to DLE and the nuget test package was successfully put on the raid for these samples to use.

The problem is because the version is the same and it's already in our cache we don't update it, so let's add a new option to clean the cache for such a scenario.