### PR TITLE
[APDFL-6735] Migrate .NET samples to APDFL 21

### DIFF
--- a/Annotations/Annotations/Annotations.csproj
+++ b/Annotations/Annotations/Annotations.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.NET" Version="21.*" />
   <PackageReference Include="Adobe.PDF.Library.SampleInput" Version="1.*" /></ItemGroup>
 
 </Project>

--- a/Annotations/InkAnnotations/InkAnnotations.csproj
+++ b/Annotations/InkAnnotations/InkAnnotations.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Annotations/LinkAnnotation/LinkAnnotation.csproj
+++ b/Annotations/LinkAnnotation/LinkAnnotation.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Annotations/PolyLineAnnotations/PolyLineAnnotations.csproj
+++ b/Annotations/PolyLineAnnotations/PolyLineAnnotations.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Annotations/PolygonAnnotations/PolygonAnnotations.csproj
+++ b/Annotations/PolygonAnnotations/PolygonAnnotations.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/AddElements/AddElements.csproj
+++ b/ContentCreation/AddElements/AddElements.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/AddHeaderFooter/AddHeaderFooter.csproj
+++ b/ContentCreation/AddHeaderFooter/AddHeaderFooter.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/Clips/Clips.csproj
+++ b/ContentCreation/Clips/Clips.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/CreateBookmarks/CreateBookmarks.csproj
+++ b/ContentCreation/CreateBookmarks/CreateBookmarks.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/GradientShade/GradientShade.csproj
+++ b/ContentCreation/GradientShade/GradientShade.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/MakeDocWithCalGrayColorSpace/MakeDocWithCalGrayColorSpace.csproj
+++ b/ContentCreation/MakeDocWithCalGrayColorSpace/MakeDocWithCalGrayColorSpace.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/MakeDocWithCalRGBColorSpace/MakeDocWithCalRGBColorSpace.csproj
+++ b/ContentCreation/MakeDocWithCalRGBColorSpace/MakeDocWithCalRGBColorSpace.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/MakeDocWithDeviceNColorSpace/MakeDocWithDeviceNColorSpace.csproj
+++ b/ContentCreation/MakeDocWithDeviceNColorSpace/MakeDocWithDeviceNColorSpace.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/MakeDocWithICCBasedColorSpace/MakeDocWithICCBasedColorSpace.csproj
+++ b/ContentCreation/MakeDocWithICCBasedColorSpace/MakeDocWithICCBasedColorSpace.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/MakeDocWithIndexedColorSpace/MakeDocWithIndexedColorSpace.csproj
+++ b/ContentCreation/MakeDocWithIndexedColorSpace/MakeDocWithIndexedColorSpace.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/MakeDocWithLabColorSpace/MakeDocWithLabColorSpace.csproj
+++ b/ContentCreation/MakeDocWithLabColorSpace/MakeDocWithLabColorSpace.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/MakeDocWithSeparationColorSpace/MakeDocWithSeparationColorSpace.csproj
+++ b/ContentCreation/MakeDocWithSeparationColorSpace/MakeDocWithSeparationColorSpace.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/NameTrees/NameTrees.csproj
+++ b/ContentCreation/NameTrees/NameTrees.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/NumberTrees/NumberTrees.csproj
+++ b/ContentCreation/NumberTrees/NumberTrees.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/RemoteGoToActions/RemoteGoToActions.csproj
+++ b/ContentCreation/RemoteGoToActions/RemoteGoToActions.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/WriteNChannelTiff/WriteNChannelTiff.csproj
+++ b/ContentCreation/WriteNChannelTiff/WriteNChannelTiff.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/Action/Action.csproj
+++ b/ContentModification/Action/Action.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/AddCollection/AddCollection.csproj
+++ b/ContentModification/AddCollection/AddCollection.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/AddQRCode/AddQRCode.csproj
+++ b/ContentModification/AddQRCode/AddQRCode.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/ChangeLayerConfiguration/ChangeLayerConfiguration.csproj
+++ b/ContentModification/ChangeLayerConfiguration/ChangeLayerConfiguration.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/ChangeLinkColors/ChangeLinkColors.csproj
+++ b/ContentModification/ChangeLinkColors/ChangeLinkColors.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/CreateLayer/CreateLayer.csproj
+++ b/ContentModification/CreateLayer/CreateLayer.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/ExtendedGraphicStates/ExtendedGraphicStates.csproj
+++ b/ContentModification/ExtendedGraphicStates/ExtendedGraphicStates.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/FlattenTransparency/FlattenTransparency.csproj
+++ b/ContentModification/FlattenTransparency/FlattenTransparency.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/LaunchActions/LaunchActions.csproj
+++ b/ContentModification/LaunchActions/LaunchActions.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/MergePDF/MergePDF.csproj
+++ b/ContentModification/MergePDF/MergePDF.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/PDFObject/PDFObject.csproj
+++ b/ContentModification/PDFObject/PDFObject.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/PageLabels/PageLabels.csproj
+++ b/ContentModification/PageLabels/PageLabels.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/UnderlinesAndHighlights/UnderlinesAndHighlights.csproj
+++ b/ContentModification/UnderlinesAndHighlights/UnderlinesAndHighlights.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/Watermark/Watermark.csproj
+++ b/ContentModification/Watermark/Watermark.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/DocumentConversion/ColorConvertDocument/ColorConvertDocument.csproj
+++ b/DocumentConversion/ColorConvertDocument/ColorConvertDocument.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/DocumentConversion/ConvertToOffice/ConvertToOffice.csproj
+++ b/DocumentConversion/ConvertToOffice/ConvertToOffice.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Platforms>x64</Platforms>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/DocumentConversion/CreateDocFromXPS/CreateDocFromXPS.csproj
+++ b/DocumentConversion/CreateDocFromXPS/CreateDocFromXPS.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/DocumentConversion/Factur-XConverter/Factur-XConverter.cs
+++ b/DocumentConversion/Factur-XConverter/Factur-XConverter.cs
@@ -5,9 +5,6 @@ using Datalogics.PDFL;
  * 
  * This sample demonstrates converting the input PDF with the input Invoice XML to a Factur-X compliant PDF.
  *
- * For more detail see the description of the Factur-XConverter sample program on our Developer’s site, 
- * http://dev.datalogics.com/adobe-pdf-library/sample-program-descriptions/net-core-sample-programs/converting-and-merging-pdf-content/#facturxconverter
- * 
  * Copyright (c) 2022-2023, Datalogics, Inc. All rights reserved.
  *
  */

--- a/DocumentConversion/Factur-XConverter/Factur-XConverter.csproj
+++ b/DocumentConversion/Factur-XConverter/Factur-XConverter.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/DocumentConversion/PDFAConverter/PDFAConverter.csproj
+++ b/DocumentConversion/PDFAConverter/PDFAConverter.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/DocumentConversion/PDFXConverter/PDFXConverter.csproj
+++ b/DocumentConversion/PDFXConverter/PDFXConverter.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/DocumentConversion/ZUGFeRDConverter/ZUGFeRDConverter.csproj
+++ b/DocumentConversion/ZUGFeRDConverter/ZUGFeRDConverter.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/DocumentOptimization/PDFOptimize/PDFOptimize.csproj
+++ b/DocumentOptimization/PDFOptimize/PDFOptimize.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Forms/ConvertXFAToAcroForms/ConvertXFAToAcroForms.csproj
+++ b/Forms/ConvertXFAToAcroForms/ConvertXFAToAcroForms.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.FormsExtension.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.FormsExtension.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Forms/ExportFormsData/ExportFormsData.csproj
+++ b/Forms/ExportFormsData/ExportFormsData.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.FormsExtension.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.FormsExtension.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Forms/FlattenForms/FlattenForms.csproj
+++ b/Forms/FlattenForms/FlattenForms.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.FormsExtension.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.FormsExtension.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Forms/ImportFormsData/ImportFormsData.csproj
+++ b/Forms/ImportFormsData/ImportFormsData.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.FormsExtension.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.FormsExtension.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Forms/README.md
+++ b/Forms/README.md
@@ -21,7 +21,7 @@ using (Library lib = new Library())
 ```
 This package supports **x64** Windows and Linux as deployment targets and is a full-featured version of the product that will expire after some time. Contact **evalsupport@datalogics.com** to extend the evaluation.
 
-[Samples](https://github.com/datalogics/apdfl-csharp-dotnet-samples/tree/main/Forms)&nbsp;|&nbsp;[Documentation](https://docs.datalogics.com/apdfl21/DotNet/index.html)&nbsp;|&nbsp;[Release Notes](https://docs.datalogics.com/apdfl21/Release_Notes.html)&nbsp;|&nbsp;[Support](https://www.datalogics.com/tech-support-pdfs)&nbsp;|&nbsp;[Homepage](https://www.datalogics.com/)
+[Samples](https://github.com/datalogics/apdfl-csharp-dotnet-samples/tree/main/Forms)&nbsp;|&nbsp;[Documentation](https://docs.datalogics.com/apdfl21/DotNet/)&nbsp;|&nbsp;[Release Notes](https://dev.datalogics.com/adobe-pdf-library-21/release-notes)&nbsp;|&nbsp;[Support](https://www.datalogics.com/tech-support-pdfs)&nbsp;|&nbsp;[Homepage](https://www.datalogics.com/)
 
 Forms Extension SDK is an Adobe PDF Library addition that helps users who work with PDF forms to efficiently manage their forms processes.  Import and export form data, lock completed forms to prevent editing and provide consistent viewing experiences across all devices. 
 

--- a/Forms/README.md
+++ b/Forms/README.md
@@ -21,7 +21,7 @@ using (Library lib = new Library())
 ```
 This package supports **x64** Windows and Linux as deployment targets and is a full-featured version of the product that will expire after some time. Contact **evalsupport@datalogics.com** to extend the evaluation.
 
-[Samples](https://github.com/datalogics/apdfl-csharp-dotnet-samples/tree/develop-21/Forms)&nbsp;|&nbsp;[Documentation](https://docs.datalogics.com/apdfl21/DotNet/)&nbsp;|&nbsp;[Release Notes](https://dev.datalogics.com/adobe-pdf-library-21/release-notes)&nbsp;|&nbsp;[Support](https://www.datalogics.com/tech-support-pdfs)&nbsp;|&nbsp;[Homepage](https://www.datalogics.com/)
+[Samples](https://github.com/datalogics/apdfl-csharp-dotnet-samples/tree/develop-21/Forms/ConvertXFAToAcroForms)&nbsp;|&nbsp;[Documentation](https://docs.datalogics.com/apdfl21/DotNet/)&nbsp;|&nbsp;[Release Notes](https://dev.datalogics.com/adobe-pdf-library-21/release-notes)&nbsp;|&nbsp;[Support](https://www.datalogics.com/tech-support-pdfs)&nbsp;|&nbsp;[Homepage](https://www.datalogics.com/)
 
 Forms Extension SDK is an Adobe PDF Library addition that helps users who work with PDF forms to efficiently manage their forms processes.  Import and export form data, lock completed forms to prevent editing and provide consistent viewing experiences across all devices. 
 

--- a/Forms/README.md
+++ b/Forms/README.md
@@ -21,7 +21,7 @@ using (Library lib = new Library())
 ```
 This package supports **x64** Windows and Linux as deployment targets and is a full-featured version of the product that will expire after some time. Contact **evalsupport@datalogics.com** to extend the evaluation.
 
-[Samples](https://github.com/datalogics/apdfl-csharp-dotnet-samples/tree/main/Forms)&nbsp;|&nbsp;[Documentation](https://docs.datalogics.com/apdfl21/DotNet/)&nbsp;|&nbsp;[Release Notes](https://dev.datalogics.com/adobe-pdf-library-21/release-notes)&nbsp;|&nbsp;[Support](https://www.datalogics.com/tech-support-pdfs)&nbsp;|&nbsp;[Homepage](https://www.datalogics.com/)
+[Samples](https://github.com/datalogics/apdfl-csharp-dotnet-samples/tree/develop-21/Forms)&nbsp;|&nbsp;[Documentation](https://docs.datalogics.com/apdfl21/DotNet/)&nbsp;|&nbsp;[Release Notes](https://dev.datalogics.com/adobe-pdf-library-21/release-notes)&nbsp;|&nbsp;[Support](https://www.datalogics.com/tech-support-pdfs)&nbsp;|&nbsp;[Homepage](https://www.datalogics.com/)
 
 Forms Extension SDK is an Adobe PDF Library addition that helps users who work with PDF forms to efficiently manage their forms processes.  Import and export form data, lock completed forms to prevent editing and provide consistent viewing experiences across all devices. 
 

--- a/Forms/README.md
+++ b/Forms/README.md
@@ -21,7 +21,7 @@ using (Library lib = new Library())
 ```
 This package supports **x64** Windows and Linux as deployment targets and is a full-featured version of the product that will expire after some time. Contact **evalsupport@datalogics.com** to extend the evaluation.
 
-[Samples](https://github.com/datalogics/apdfl-csharp-dotnet-samples/tree/main/Forms)&nbsp;|&nbsp;[Documentation](https://docs.datalogics.com/apdfl18/DotNet/index.html)&nbsp;|&nbsp;[Release Notes](https://docs.datalogics.com/apdfl18/Release_Notes.html)&nbsp;|&nbsp;[Support](https://www.datalogics.com/tech-support-pdfs)&nbsp;|&nbsp;[Homepage](https://www.datalogics.com/)
+[Samples](https://github.com/datalogics/apdfl-csharp-dotnet-samples/tree/main/Forms)&nbsp;|&nbsp;[Documentation](https://docs.datalogics.com/apdfl21/DotNet/index.html)&nbsp;|&nbsp;[Release Notes](https://docs.datalogics.com/apdfl21/Release_Notes.html)&nbsp;|&nbsp;[Support](https://www.datalogics.com/tech-support-pdfs)&nbsp;|&nbsp;[Homepage](https://www.datalogics.com/)
 
 Forms Extension SDK is an Adobe PDF Library addition that helps users who work with PDF forms to efficiently manage their forms processes.  Import and export form data, lock completed forms to prevent editing and provide consistent viewing experiences across all devices. 
 

--- a/Images/DocToImages/DocToImages.csproj
+++ b/Images/DocToImages/DocToImages.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Images/DrawSeparations/DrawSeparations.csproj
+++ b/Images/DrawSeparations/DrawSeparations.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
     <PackageReference Include="SkiaSharp" Version="3.119.*" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.*" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.*" />

--- a/Images/DrawToBitmap/DrawToBitmap.csproj
+++ b/Images/DrawToBitmap/DrawToBitmap.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
     <PackageReference Include="SkiaSharp" Version="3.119.*" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.*" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.*" />

--- a/Images/EPSSeparations/EPSSeparations.csproj
+++ b/Images/EPSSeparations/EPSSeparations.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Images/GetSeparatedImages/GetSeparatedImages.csproj
+++ b/Images/GetSeparatedImages/GetSeparatedImages.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Images/ImageEmbedICCProfile/ImageEmbedICCProfile.csproj
+++ b/Images/ImageEmbedICCProfile/ImageEmbedICCProfile.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Images/ImageExport/ImageExport.csproj
+++ b/Images/ImageExport/ImageExport.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Images/ImageExtraction/ImageExtraction.csproj
+++ b/Images/ImageExtraction/ImageExtraction.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
     <PackageReference Include="SkiaSharp" Version="3.119.*" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.*" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.*" />

--- a/Images/ImageFromStream/ImageFromStream.csproj
+++ b/Images/ImageFromStream/ImageFromStream.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
     <PackageReference Include="SkiaSharp" Version="3.119.*" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.*" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.*" />

--- a/Images/ImageImport/ImageImport.csproj
+++ b/Images/ImageImport/ImageImport.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Images/ImageResampling/ImageResampling.csproj
+++ b/Images/ImageResampling/ImageResampling.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Images/ImageSoftMask/ImageSoftMask.csproj
+++ b/Images/ImageSoftMask/ImageSoftMask.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Images/OutputPreview/OutputPreview.csproj
+++ b/Images/OutputPreview/OutputPreview.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Images/RasterizePage/RasterizePage.csproj
+++ b/Images/RasterizePage/RasterizePage.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
     <PackageReference Include="SkiaSharp" Version="3.119.*" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.*" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.*" />

--- a/InformationExtraction/ListBookmarks/ListBookmarks.csproj
+++ b/InformationExtraction/ListBookmarks/ListBookmarks.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/InformationExtraction/ListInfo/ListInfo.csproj
+++ b/InformationExtraction/ListInfo/ListInfo.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/InformationExtraction/ListLayers/ListLayers.csproj
+++ b/InformationExtraction/ListLayers/ListLayers.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/InformationExtraction/ListPaths/ListPaths.csproj
+++ b/InformationExtraction/ListPaths/ListPaths.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/InformationExtraction/Metadata/Metadata.csproj
+++ b/InformationExtraction/Metadata/Metadata.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 def ENV_LOC=[:]
 pipeline {
     parameters {
-        choice(name: 'PLATFORM_FILTER', choices: ['all', 'windows-dotnet-samples', 'linux-dotnet-samples', 'mac-arm-dotnet-samples', 'mac-intel-dotnet-samples','linux-arm-dotnet-samples'], description: 'Run on specific platform')
+        choice(name: 'PLATFORM_FILTER', choices: ['all', 'windows-dotnet-samples', 'rocky9-dotnet-samples', 'mac-arm-dotnet-samples', 'mac-intel-dotnet-samples', 'rocky9-arm-dotnet-samples'], description: 'Run on specific platform')
         booleanParam defaultValue: false, description: 'Completely clean the workspace before building, including the Conan cache', name: 'CLEAN_WORKSPACE'
         booleanParam defaultValue: false, description: 'Run clean-samples', name: 'DISTCLEAN'
         booleanParam defaultValue: true, description: 'Run clean-nuget-cache', name: 'NUGETCLEAN'
@@ -32,7 +32,7 @@ pipeline {
                 axes {
                     axis {
                         name 'NODE'
-                        values 'windows-dotnet-samples', 'linux-dotnet-samples', 'mac-arm-dotnet-samples', 'mac-intel-dotnet-samples','linux-arm-dotnet-samples'
+                        values 'windows-dotnet-samples', 'rocky9-dotnet-samples', 'mac-arm-dotnet-samples', 'mac-intel-dotnet-samples','rocky9-arm-dotnet-samples'
                     }
                 }
                 stages {

--- a/OpticalCharacterRecognition/AddTextToDocument/AddTextToDocument.csproj
+++ b/OpticalCharacterRecognition/AddTextToDocument/AddTextToDocument.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/OpticalCharacterRecognition/AddTextToImage/AddTextToImage.csproj
+++ b/OpticalCharacterRecognition/AddTextToImage/AddTextToImage.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/OpticalCharacterRecognition/OCRDocument/OCRDocument.csproj
+++ b/OpticalCharacterRecognition/OCRDocument/OCRDocument.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Other/MemoryFileSystem/MemoryFileSystem.csproj
+++ b/Other/MemoryFileSystem/MemoryFileSystem.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Other/StreamIO/StreamIO.csproj
+++ b/Other/StreamIO/StreamIO.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Datalogics Adobe PDF Library](https://raw.github.com/datalogics/dl-icons/develop/DLBanner_Nuget.png)
 
-[Documentation](https://dev.datalogics.com/adobe-pdf-library/dot-net/getting-started) &nbsp;| [API Reference](https://docs.datalogics.com/apdfl21/DotNet/) &nbsp;|&nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp; [Release Notes](https://dev.datalogics.com/adobe-pdf-library/release-notes) &nbsp; | &nbsp;[Discord](https://discord.gg/jNSHcSdRre)
+[Documentation](https://dev.datalogics.com/adobe-pdf-library-21/dot-net/getting-started) &nbsp;| [API Reference](https://docs.datalogics.com/apdfl21/DotNet/) &nbsp;|&nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp; [Release Notes](https://dev.datalogics.com/adobe-pdf-library-21/release-notes) &nbsp; | &nbsp;[Discord](https://discord.gg/jNSHcSdRre)
 
 [![Download a Free Trial on NuGet](https://img.shields.io/nuget/dt/Adobe.PDF.Library.LM.NET?color=blue&label=APDFL%20.NET%20Free%20Trial&logo=NuGet&style=plastic)](https://www.nuget.org/packages/Adobe.PDF.Library.LM.NET)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Datalogics Adobe PDF Library](https://raw.github.com/datalogics/dl-icons/develop/DLBanner_Nuget.png)
 
-[Documentation](https://dev.datalogics.com/adobe-pdf-library/dot-net/getting-started) &nbsp;| [API Reference](https://docs.datalogics.com/apdfl21/DotNet/index.html) &nbsp;|&nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp; [Release Notes](https://dev.datalogics.com/adobe-pdf-library/release-notes) &nbsp; | &nbsp;[Discord](https://discord.gg/jNSHcSdRre)
+[Documentation](https://dev.datalogics.com/adobe-pdf-library/dot-net/getting-started) &nbsp;| [API Reference](https://docs.datalogics.com/apdfl21/DotNet/) &nbsp;|&nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp; [Release Notes](https://dev.datalogics.com/adobe-pdf-library/release-notes) &nbsp; | &nbsp;[Discord](https://discord.gg/jNSHcSdRre)
 
 [![Download a Free Trial on NuGet](https://img.shields.io/nuget/dt/Adobe.PDF.Library.LM.NET?color=blue&label=APDFL%20.NET%20Free%20Trial&logo=NuGet&style=plastic)](https://www.nuget.org/packages/Adobe.PDF.Library.LM.NET)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Datalogics Adobe PDF Library](https://raw.github.com/datalogics/dl-icons/develop/DLBanner_Nuget.png)
 
-[Documentation](https://dev.datalogics.com/adobe-pdf-library/dot-net/getting-started) &nbsp;| [API Reference](https://docs.datalogics.com/apdfl18/DotNet/index.html) &nbsp;|&nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp; [Release Notes](https://dev.datalogics.com/adobe-pdf-library/release-notes) &nbsp; | &nbsp;[Discord](https://discord.gg/jNSHcSdRre)
+[Documentation](https://dev.datalogics.com/adobe-pdf-library/dot-net/getting-started) &nbsp;| [API Reference](https://docs.datalogics.com/apdfl21/DotNet/index.html) &nbsp;|&nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp; [Release Notes](https://dev.datalogics.com/adobe-pdf-library/release-notes) &nbsp; | &nbsp;[Discord](https://discord.gg/jNSHcSdRre)
 
 [![Download a Free Trial on NuGet](https://img.shields.io/nuget/dt/Adobe.PDF.Library.LM.NET?color=blue&label=APDFL%20.NET%20Free%20Trial&logo=NuGet&style=plastic)](https://www.nuget.org/packages/Adobe.PDF.Library.LM.NET)
 

--- a/Security/AddBasicPAdESElectronicSignature/AddBasicPAdESElectronicSignature.csproj
+++ b/Security/AddBasicPAdESElectronicSignature/AddBasicPAdESElectronicSignature.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Security/AddDigitalSignatureCMS/AddDigitalSignatureCMS.csproj
+++ b/Security/AddDigitalSignatureCMS/AddDigitalSignatureCMS.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Security/AddDigitalSignatureRFC3161/AddDigitalSignatureRFC3161.csproj
+++ b/Security/AddDigitalSignatureRFC3161/AddDigitalSignatureRFC3161.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Security/AddPAdESPolicySignature/AddPAdESPolicySignature.csproj
+++ b/Security/AddPAdESPolicySignature/AddPAdESPolicySignature.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Security/AddRegexRedaction/AddRegexRedaction.csproj
+++ b/Security/AddRegexRedaction/AddRegexRedaction.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Security/Redactions/Redactions.csproj
+++ b/Security/Redactions/Redactions.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Text/AddGlyphs/AddGlyphs.csproj
+++ b/Text/AddGlyphs/AddGlyphs.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Text/AddUnicodeText/AddUnicodeText.csproj
+++ b/Text/AddUnicodeText/AddUnicodeText.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Text/AddVerticalText/AddVerticalText.csproj
+++ b/Text/AddVerticalText/AddVerticalText.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Text/ExtractAcroFormFieldData/ExtractAcroFormFieldData.csproj
+++ b/Text/ExtractAcroFormFieldData/ExtractAcroFormFieldData.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="../../_Common/ExtractText.cs" Link="ExtractText.cs" />

--- a/Text/ExtractCJKTextByPatternMatch/ExtractCJKTextByPatternMatch.csproj
+++ b/Text/ExtractCJKTextByPatternMatch/ExtractCJKTextByPatternMatch.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Text/ExtractTextByPatternMatch/ExtractTextByPatternMatch.csproj
+++ b/Text/ExtractTextByPatternMatch/ExtractTextByPatternMatch.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Text/ExtractTextByRegion/ExtractTextByRegion.csproj
+++ b/Text/ExtractTextByRegion/ExtractTextByRegion.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="../../_Common/ExtractText.cs" Link="ExtractText.cs" />

--- a/Text/ExtractTextFromAnnotations/ExtractTextFromAnnotations.csproj
+++ b/Text/ExtractTextFromAnnotations/ExtractTextFromAnnotations.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="../../_Common/ExtractText.cs" Link="ExtractText.cs" />

--- a/Text/ExtractTextFromMultiRegions/ExtractTextFromMultiRegions.csproj
+++ b/Text/ExtractTextFromMultiRegions/ExtractTextFromMultiRegions.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="../../_Common/ExtractText.cs" Link="ExtractText.cs" />

--- a/Text/ExtractTextPreservingStyleAndPositionInfo/ExtractTextPreservingStyleAndPositionInfo.csproj
+++ b/Text/ExtractTextPreservingStyleAndPositionInfo/ExtractTextPreservingStyleAndPositionInfo.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="../../_Common/ExtractText.cs" Link="ExtractText.cs" />

--- a/Text/ListWords/ListWords.csproj
+++ b/Text/ListWords/ListWords.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Text/RegexExtractText/RegexExtractText.csproj
+++ b/Text/RegexExtractText/RegexExtractText.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Text/RegexTextSearch/RegexTextSearch.csproj
+++ b/Text/RegexTextSearch/RegexTextSearch.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Text/TextExtract/TextExtract.csproj
+++ b/Text/TextExtract/TextExtract.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
Migrates all 91 .NET sample projects from Adobe PDF Library 18 to APDFL 21.

- Bump APDFL package references `18.*` → `21.*` (`Adobe.PDF.Library.LM.NET`, `Adobe.PDF.Library.NET`, `Adobe.PDF.Library.FormsExtension.LM.NET`).
- Retarget all projects `net8.0` → `net10.0`. **Required:** the APDFL 21 packages ship their managed `Datalogics.PDFL.dll` only under `lib/net10.0`, so net8.0 projects can no longer restore against them.
- Update API-reference / documentation / release-notes links `apdfl18` → `apdfl21` in `README.md` and `Forms/README.md`.

#### Fullfils Jira issue [APDFL-6735](https://datalogics-jira.atlassian.net/browse/APDFL-6735)

## Verification
Built and run against the 21.0.0 packages on osx-arm64:
- `LM.NET` — TextExtract (extracted 8 pages, wrote output); RasterizePage (produced 3 PNGs, SkiaSharp integration).
- Full `Adobe.PDF.Library.NET` — Annotations (initialized, read input, listed annotations).
- `FormsExtension.LM.NET` — builds cleanly. That product ships only win-x64/linux-x64 natives (unchanged from v18), so Forms samples require Windows/Linux at runtime.

## Notes
Requires the .NET 10 SDK to build (was .NET 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APDFL-6735]: https://datalogics-jira.atlassian.net/browse/APDFL-6735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ